### PR TITLE
Add unit tests for HabitController #6

### DIFF
--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,6 +1,9 @@
 package greencity.controller;
 
 import greencity.converters.UserArgumentResolver;
+import greencity.dto.PageableDto;
+import greencity.dto.habit.HabitDto;
+import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.HabitService;
 import greencity.service.TagsService;
 import greencity.service.UserService;
@@ -11,18 +14,27 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.security.Principal;
+import java.util.Locale;
 
 import static greencity.ModelUtils.getPrincipal;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 public class HabitControllerTest {
-    public static final String BASE = "/habit";
+    public static final String habitLink = "/habit";
     private MockMvc mockMvc;
     private ObjectMapper objectMapper;
 
@@ -37,20 +49,63 @@ public class HabitControllerTest {
 
     @Mock
     private UserService userService;
+
     @Mock
     private ModelMapper modelMapper;
 
     private Principal principal = getPrincipal();
+    private final ErrorAttributes errorAttributes = new DefaultErrorAttributes();
 
     @BeforeEach
     void setUp() {
-        this.mockMvc = MockMvcBuilders.standaloneSetup(habitController)
-                .setCustomArgumentResolvers(
-                        new PageableHandlerMethodArgumentResolver(),
-                        new UserArgumentResolver(userService, modelMapper))
+        objectMapper = new ObjectMapper();
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(habitController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                        new UserArgumentResolver(null, null))
+                .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper))
                 .build();
     }
 
     @Test
+    void getHabitByIdTest() throws Exception {
+        mockMvc.perform(get(habitLink + "/{id}", 1L)
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
 
+        verify(habitService).getByIdAndLanguageCode(1L, "en");
+    }
+
+    @Test
+    void getAllTest() throws Exception {
+        mockMvc.perform(get(habitLink)
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
+
+        verify(habitService).getAllHabitsByLanguageCode(isNull(), any(Pageable.class), eq("en"));
+    }
+
+    @Test
+    void getShoppingListItemsTest() throws Exception {
+        mockMvc.perform(get(habitLink + "/{id}/shopping-list", 1L)
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
+
+        verify(habitService).getShoppingListForHabit(1L, "en");
+    }
+
+    @Test
+    void getAllByTagsAndLanguageCodeTest() throws Exception {
+       PageableDto<HabitDto> emptyResult = new PageableDto<>();
+       when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), anyList(), anyString()))
+               .thenReturn(emptyResult);
+
+        mockMvc.perform(get(habitLink + "/tags/search")
+                        .param("tags", "tag1", "tag2")
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
+
+        verify(habitService).getAllByTagsAndLanguageCode(any(Pageable.class),
+                anyList(), eq("en"));
+    }
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -5,6 +5,7 @@ import greencity.service.HabitService;
 import greencity.service.TagsService;
 import greencity.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -49,5 +50,7 @@ public class HabitControllerTest {
                         new UserArgumentResolver(userService, modelMapper))
                 .build();
     }
+
+    @Test
 
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -6,8 +6,15 @@ import greencity.dto.habit.AddCustomHabitDtoRequest;
 import greencity.dto.habit.AddCustomHabitDtoResponse;
 import greencity.dto.habit.HabitDto;
 
+import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
+import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import greencity.dto.user.UserProfilePictureDto;
 import greencity.dto.user.UserVO;
+import greencity.enums.HabitAssignStatus;
+import greencity.enums.Role;
+import greencity.enums.ShoppingListItemStatus;
+import greencity.enums.UserStatus;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.HabitService;
 
@@ -22,34 +29,35 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.multipart.MultipartFile;
 
 
 import java.security.Principal;
-import java.util.List;
-import java.util.Locale;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Stream;
 
-import java.util.Set;
-
-import static greencity.ModelUtils.getPrincipal;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 public class HabitControllerTest {
+
     public static final String habitLink = "/habit";
+
     private MockMvc mockMvc;
-    private ObjectMapper objectMapper;
 
     @InjectMocks
     private HabitController habitController;
@@ -66,130 +74,350 @@ public class HabitControllerTest {
     @Mock
     private ModelMapper modelMapper;
 
-    private Principal principal = getPrincipal();
+    ObjectMapper objectMapper;
+
+    Principal principal = () -> "test@mail.com";
+
+    UserVO user = new UserVO();
+    HabitDto habit1 = new HabitDto();
+    HabitDto habit2 = new HabitDto();
+    List<HabitDto> habits = new ArrayList<>();
+    PageableDto<HabitDto> pageableDto = new PageableDto<>();
+    Locale locale = Locale.ENGLISH;
+    Pageable pageable = PageRequest.of(0, 20);
+
     private final ErrorAttributes errorAttributes = new DefaultErrorAttributes();
 
     @BeforeEach
     void setUp() {
-        objectMapper = new ObjectMapper();
+
         this.mockMvc = MockMvcBuilders
                 .standaloneSetup(habitController)
                 .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                        new UserArgumentResolver(null, null))
+                        new UserArgumentResolver(userService, modelMapper))
                 .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper))
+                .build();
+
+        user = UserVO.builder()
+                .id(1L)
+                .name("Andrii Shevchenko")
+                .email("test@mail.com")
+                .role(Role.ROLE_USER)
+                .userCredo("Do it!")
+                .userStatus(UserStatus.ACTIVATED)
+                .rating(4.0)
+                .dateOfRegistration(LocalDateTime.now().minusMonths(3))
+                .lastActivityTime(LocalDateTime.now())
+                .firstName("Andrii")
+                .city("Chernivtsi")
+                .build();
+
+        habit1 = HabitDto.builder()
+                .id(1L)
+                .defaultDuration(30)
+                .amountAcquiredUsers(100L)
+                .complexity(2)
+                .image("habit1.png")
+                .tags(List.of("fitness", "morning"))
+                .shoppingListItems(List.of(
+                        ShoppingListItemDto.builder()
+                                .id(1L)
+                                .text("Water Bottle")
+                                .status("Ready to start")
+                                .build()
+                ))
+                .customShoppingListItems(Collections.emptyList())
+                .isCustomHabit(false)
+                .usersIdWhoCreatedCustomHabit(null)
+                .habitAssignStatus(HabitAssignStatus.INPROGRESS)
+                .habitTranslation(HabitTranslationDto.builder()
+                        .name("Running")
+                        .languageCode("en")
+                        .description("Running in park")
+                        .habitItem(null)
+                        .build())
+                .build();
+
+        habit2 = HabitDto.builder()
+                .id(2L)
+                .defaultDuration(45)
+                .amountAcquiredUsers(10L)
+                .complexity(3)
+                .image("habit2.png")
+                .tags(List.of("nutrition", "evening"))
+                .shoppingListItems(List.of(
+                        ShoppingListItemDto.builder()
+                                .id(2L)
+                                .text("Protein Powder")
+                                .status("Ready to start")
+                                .build()
+                ))
+                .customShoppingListItems(List.of(
+                        CustomShoppingListItemResponseDto.builder()
+                                .id(1L)
+                                .text("Almond Milk")
+                                .status(ShoppingListItemStatus.ACTIVE)
+                                .build()
+                ))
+                .isCustomHabit(true)
+                .usersIdWhoCreatedCustomHabit(123L)
+                .habitAssignStatus(HabitAssignStatus.REQUESTED)
+                .habitTranslation(HabitTranslationDto.builder()
+                        .name("Evening Protein Shake")
+                        .languageCode("en")
+                        .description("Evening protein shake for recovery")
+                        .habitItem(null)
+                        .build())
                 .build();
     }
 
     @Test
     void getHabitByIdTest() throws Exception {
-        mockMvc.perform(get(habitLink + "/{id}", 1L)
-                        .locale(Locale.ENGLISH))
+        when(habitService.getByIdAndLanguageCode(eq(habit1.getId()), eq(locale.getLanguage())))
+                .thenReturn(habit1);
+
+        mockMvc.perform(get(habitLink + "/{id}", habit1.getId())
+                        .locale(locale)
+                        .principal(principal))
                 .andExpect(status().isOk());
 
-        verify(habitService).getByIdAndLanguageCode(1L, "en");
+        verify(habitService).getByIdAndLanguageCode(eq(habit1.getId()), eq(locale.getLanguage()));
     }
 
     @Test
     void getAllTest() throws Exception {
-        mockMvc.perform(get(habitLink)
-                        .locale(Locale.ENGLISH))
-                .andExpect(status().isOk());
+        habits = List.of(habit1, habit2);
+        pageableDto = new PageableDto<>(habits, habits.size(), 0, 1);
 
-        verify(habitService).getAllHabitsByLanguageCode(isNull(), any(Pageable.class), eq("en"));
+        when(userService.findByEmail(anyString())).thenReturn(user);
+        when(habitService.getAllHabitsByLanguageCode(eq(user), eq(pageable), eq(locale.getLanguage())))
+                .thenReturn(pageableDto);
+
+        mockMvc.perform(get(habitLink)
+                .locale(locale)
+                .principal(principal)
+        ).andExpect(status().isOk());
+
+        verify(habitService).getAllHabitsByLanguageCode(eq(user), eq(pageable), eq(locale.getLanguage()));
     }
 
     @Test
     void getShoppingListItemsTest() throws Exception {
-        mockMvc.perform(get(habitLink + "/{id}/shopping-list", 1L)
-                        .locale(Locale.ENGLISH))
+        List<ShoppingListItemDto> shoppingListItemDtos = Stream.concat(
+                habit1.getShoppingListItems().stream(),
+                habit2.getShoppingListItems().stream()
+        ).toList();
+
+        when(habitService.getShoppingListForHabit(eq(habit1.getId()), eq(locale.getLanguage())))
+                .thenReturn(shoppingListItemDtos);
+
+        mockMvc.perform(get(habitLink + "/{id}/shopping-list", habit1.getId())
+                        .locale(locale))
                 .andExpect(status().isOk());
 
-        verify(habitService).getShoppingListForHabit(1L, "en");
+        verify(habitService).getShoppingListForHabit(eq(habit1.getId()), eq(locale.getLanguage()));
     }
 
     @Test
     void getAllByTagsAndLanguageCodeTest() throws Exception {
-        PageableDto<HabitDto> emptyResult = new PageableDto<>();
-        when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), anyList(), anyString()))
-                .thenReturn(emptyResult);
+        List<String> tags = Stream.concat(
+                habit1.getTags().stream(),
+                habit2.getTags().stream()
+        ).toList();
+        pageableDto = new PageableDto<>(habits, tags.size(), 0, 1);
+
+        when(habitService.getAllByTagsAndLanguageCode(eq(pageable), eq(tags), eq(locale.getLanguage())))
+                .thenReturn(pageableDto);
 
         mockMvc.perform(get(habitLink + "/tags/search")
-                        .param("tags", "tag1", "tag2")
-                        .locale(Locale.ENGLISH))
+                        .locale(locale)
+                        .param("tags", tags.toArray(new String[0]))
+                        .param("page", String.valueOf(pageable.getPageNumber()))
+                        .param("size", String.valueOf(pageable.getPageSize())))
                 .andExpect(status().isOk());
 
-        verify(habitService).getAllByTagsAndLanguageCode(any(Pageable.class),
-                anyList(), eq("en"));
+        verify(habitService).getAllByTagsAndLanguageCode(eq(pageable), eq(tags), eq(locale.getLanguage()));
     }
 
     @Test
     void getAllByDifferentParametersTest() throws Exception {
+        when(userService.findByEmail(anyString())).thenReturn(user);
+
+        List<String> tags = Stream.concat(
+                habit1.getTags().stream(),
+                habit2.getTags().stream()
+        ).toList();
+        Boolean isCustomHabit = habit1.getIsCustomHabit();
+        List<Integer> complexities = List.of(habit1.getComplexity(), habit2.getComplexity());
+        pageableDto = new PageableDto<>(habits, habits.size(), 0, 1);
+
         when(habitService.getAllByDifferentParameters(
-                any(), any(), any(), any(), any(), eq("en")
-        )).thenReturn(new PageableDto<>());
+                eq(user),
+                eq(pageable),
+                eq(Optional.of(tags)),
+                eq(Optional.of(isCustomHabit)),
+                eq(Optional.of(complexities)),
+                eq(locale.getLanguage()))
+        ).thenReturn(pageableDto);
 
         mockMvc.perform(get(habitLink + "/search")
-                        .param("tags", "tag1", "tag2")
-                        .locale(Locale.ENGLISH))
+                        .principal(principal)
+                        .param("tags", tags.toArray(new String[0]))
+                        .param("isCustomHabit", String.valueOf(isCustomHabit))
+                        .param("complexities", complexities.stream().map(String::valueOf).toArray(String[]::new))
+                        .param("page", String.valueOf(pageable.getPageNumber()))
+                        .param("size", String.valueOf(pageable.getPageSize())))
                 .andExpect(status().isOk());
 
-        verify(habitService).getAllByDifferentParameters(any(), any(), any(), any(), any(), eq("en"));
+        verify(habitService).getAllByDifferentParameters(eq(user),
+                eq(pageable),
+                eq(Optional.of(tags)),
+                eq(Optional.of(isCustomHabit)),
+                eq(Optional.of(complexities)),
+                eq(locale.getLanguage()));
+    }
+
+    @Test
+    void getAllByDifferentParametersBadRequestTest() throws Exception {
+        when(userService.findByEmail(anyString())).thenReturn(user);
+        mockMvc.perform(get(habitLink + "/search")
+                        .principal(principal)
+                        .locale(locale)
+                        .param("page", String.valueOf(pageable.getPageNumber()))
+                        .param("size", String.valueOf(pageable.getPageSize()))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(xpath("/ExceptionResponse/message").string("No message available"));
     }
 
     @Test
     void findAllHabitsTagsTest() throws Exception {
-        when(tagsService.findAllHabitsTags(anyString()))
-                .thenReturn(List.of("tag1", "tag2"));
+        List<String> tags = Stream.concat(
+                habit1.getTags().stream(),
+                habit2.getTags().stream()
+        ).toList();
+
+        when(tagsService.findAllHabitsTags(eq(locale.getLanguage())))
+                .thenReturn(tags);
 
         mockMvc.perform(get(habitLink + "/tags")
-                        .locale(Locale.ENGLISH))
+                        .locale(locale))
                 .andExpect(status().isOk());
 
-        verify(tagsService).findAllHabitsTags("en");
+        verify(tagsService).findAllHabitsTags(eq(locale.getLanguage()));
     }
 
     @Test
     void addCustomHabitTest() throws Exception {
         AddCustomHabitDtoRequest request = AddCustomHabitDtoRequest.builder()
                 .complexity(2)
-                .tagIds(Set.of(1L))
+                .defaultDuration(7)
+                .habitTranslations(List.of(
+                        HabitTranslationDto.builder()
+                                .name("Running")
+                                .languageCode("en")
+                                .description("Running in park")
+                                .habitItem(null)
+                                .build(),
+                        HabitTranslationDto.builder()
+                                .name("Evening Protein Shake")
+                                .languageCode("en")
+                                .description("Evening protein shake for recovery")
+                                .habitItem("Cup for protein")
+                                .build()))
+                .image("image.png")
+                .customShoppingListItemDto(List.of(
+                        CustomShoppingListItemResponseDto.builder()
+                                .id(1L)
+                                .text("Almond Milk")
+                                .status(ShoppingListItemStatus.ACTIVE)
+                                .build()
+                ))
+                .tagIds(Set.of(1L, 2L))
                 .build();
 
-        MockMultipartFile jsonFile = new MockMultipartFile(
-                "request", "request.json", "application/json",
+        AddCustomHabitDtoResponse response = AddCustomHabitDtoResponse.builder()
+                .id(1L)
+                .userId(42L)
+                .complexity(request.getComplexity())
+                .defaultDuration(request.getDefaultDuration())
+                .habitTranslations(request.getHabitTranslations())
+                .customShoppingListItemDto(request.getCustomShoppingListItemDto())
+                .tagIds(request.getTagIds())
+                .image(request.getImage())
+                .build();
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "image.png",
+                "image/png",
+                "dummy image content".getBytes()
+        );
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "request",
+                "",
+                "application/json",
                 new ObjectMapper().writeValueAsBytes(request)
         );
 
-        MockMultipartFile image = new MockMultipartFile(
-                "image", "image.png", "image/png",
-                "dummy".getBytes()
-        );
-
-        when(habitService.addCustomHabit(any(), any(), anyString()))
-                .thenReturn(new AddCustomHabitDtoResponse());
+        when(habitService.addCustomHabit(eq(request), any(MultipartFile.class), eq(principal.getName())))
+                .thenReturn(response);
 
         mockMvc.perform(multipart(habitLink + "/custom")
-                        .file(jsonFile)
                         .file(image)
-                        .principal(principal))
+                        .file(jsonPart)
+                        .principal(principal)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isCreated());
-
-        verify(habitService).addCustomHabit(any(), any(), eq("test@gmail.com"));
     }
+
+    @Test
+    void addCustomHabitBadRequestTest() throws Exception {
+        AddCustomHabitDtoRequest emptyRequest = new AddCustomHabitDtoRequest();
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "image.png",
+                "image/png",
+                "dummy image content".getBytes()
+        );
+        MockMultipartFile jsonPart = new MockMultipartFile(
+                "request",
+                "",
+                "application/json",
+                new ObjectMapper().writeValueAsBytes(emptyRequest)
+        );
+
+        mockMvc.perform(multipart(habitLink + "/custom")
+                        .file(image)
+                        .file(jsonPart)
+                        .principal(principal)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest());
+    }
+
     @Test
     void getFriendsAssignedToHabitProfilePicturesTest() throws Exception {
-        Long habitId = 1L;
-        UserVO userVO = new UserVO();
-        userVO.setId(1L);
+        when(userService.findByEmail(anyString())).thenReturn(user);
 
-        when(habitService.getFriendsAssignedToHabitProfilePictures(habitId, userVO.getId()))
-                .thenReturn(List.of(new UserProfilePictureDto(), new UserProfilePictureDto()));
+        List<UserProfilePictureDto> userProfilePictureDtos = List.of(UserProfilePictureDto.builder()
+                        .id(1L)
+                        .name("Carrot")
+                        .profilePicturePath("carrot.png")
+                        .build(),
+                UserProfilePictureDto.builder()
+                        .id(1L)
+                        .name("Watermelon")
+                        .profilePicturePath("watermelon.png")
+                        .build()
+        );
 
-        mockMvc.perform(get(habitLink + "/{habitId}/friends/profile-pictures", habitId)
-                        .principal(principal)
-                        .locale(Locale.ENGLISH))
-                .andExpect(status().isOk());
+        when(habitService.getFriendsAssignedToHabitProfilePictures(eq(habit1.getId()), eq(user.getId())))
+                .thenReturn(userProfilePictureDtos);
 
-        verify(habitService).getFriendsAssignedToHabitProfilePictures(habitId, userVO.getId());
+        mockMvc.perform(get(habitLink + "/{habitId}/friends/profile-pictures", habit1.getId())
+                .principal(principal)).andExpect(status().isOk());
+
+        verify(habitService).getFriendsAssignedToHabitProfilePictures(eq(habit1.getId()), eq(user.getId()));
     }
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -2,9 +2,15 @@ package greencity.controller;
 
 import greencity.converters.UserArgumentResolver;
 import greencity.dto.PageableDto;
+import greencity.dto.habit.AddCustomHabitDtoRequest;
+import greencity.dto.habit.AddCustomHabitDtoResponse;
 import greencity.dto.habit.HabitDto;
+
+import greencity.dto.user.UserProfilePictureDto;
+import greencity.dto.user.UserVO;
 import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.HabitService;
+
 import greencity.service.TagsService;
 import greencity.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,18 +24,25 @@ import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+
 import java.security.Principal;
+import java.util.List;
 import java.util.Locale;
+
+import java.util.Set;
 
 import static greencity.ModelUtils.getPrincipal;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,9 +109,9 @@ public class HabitControllerTest {
 
     @Test
     void getAllByTagsAndLanguageCodeTest() throws Exception {
-       PageableDto<HabitDto> emptyResult = new PageableDto<>();
-       when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), anyList(), anyString()))
-               .thenReturn(emptyResult);
+        PageableDto<HabitDto> emptyResult = new PageableDto<>();
+        when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), anyList(), anyString()))
+                .thenReturn(emptyResult);
 
         mockMvc.perform(get(habitLink + "/tags/search")
                         .param("tags", "tag1", "tag2")
@@ -107,5 +120,76 @@ public class HabitControllerTest {
 
         verify(habitService).getAllByTagsAndLanguageCode(any(Pageable.class),
                 anyList(), eq("en"));
+    }
+
+    @Test
+    void getAllByDifferentParametersTest() throws Exception {
+        when(habitService.getAllByDifferentParameters(
+                any(), any(), any(), any(), any(), eq("en")
+        )).thenReturn(new PageableDto<>());
+
+        mockMvc.perform(get(habitLink + "/search")
+                        .param("tags", "tag1", "tag2")
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
+
+        verify(habitService).getAllByDifferentParameters(any(), any(), any(), any(), any(), eq("en"));
+    }
+
+    @Test
+    void findAllHabitsTagsTest() throws Exception {
+        when(tagsService.findAllHabitsTags(anyString()))
+                .thenReturn(List.of("tag1", "tag2"));
+
+        mockMvc.perform(get(habitLink + "/tags")
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
+
+        verify(tagsService).findAllHabitsTags("en");
+    }
+
+    @Test
+    void addCustomHabitTest() throws Exception {
+        AddCustomHabitDtoRequest request = AddCustomHabitDtoRequest.builder()
+                .complexity(2)
+                .tagIds(Set.of(1L))
+                .build();
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "request", "request.json", "application/json",
+                new ObjectMapper().writeValueAsBytes(request)
+        );
+
+        MockMultipartFile image = new MockMultipartFile(
+                "image", "image.png", "image/png",
+                "dummy".getBytes()
+        );
+
+        when(habitService.addCustomHabit(any(), any(), anyString()))
+                .thenReturn(new AddCustomHabitDtoResponse());
+
+        mockMvc.perform(multipart(habitLink + "/custom")
+                        .file(jsonFile)
+                        .file(image)
+                        .principal(principal))
+                .andExpect(status().isCreated());
+
+        verify(habitService).addCustomHabit(any(), any(), eq("test@gmail.com"));
+    }
+    @Test
+    void getFriendsAssignedToHabitProfilePicturesTest() throws Exception {
+        Long habitId = 1L;
+        UserVO userVO = new UserVO();
+        userVO.setId(1L);
+
+        when(habitService.getFriendsAssignedToHabitProfilePictures(habitId, userVO.getId()))
+                .thenReturn(List.of(new UserProfilePictureDto(), new UserProfilePictureDto()));
+
+        mockMvc.perform(get(habitLink + "/{habitId}/friends/profile-pictures", habitId)
+                        .principal(principal)
+                        .locale(Locale.ENGLISH))
+                .andExpect(status().isOk());
+
+        verify(habitService).getFriendsAssignedToHabitProfilePictures(habitId, userVO.getId());
     }
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,0 +1,53 @@
+package greencity.controller;
+
+import greencity.converters.UserArgumentResolver;
+import greencity.service.HabitService;
+import greencity.service.TagsService;
+import greencity.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.security.Principal;
+
+import static greencity.ModelUtils.getPrincipal;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitControllerTest {
+    public static final String BASE = "/habit";
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private HabitController habitController;
+
+    @Mock
+    private HabitService habitService;
+
+    @Mock
+    private TagsService tagsService;
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private ModelMapper modelMapper;
+
+    private Principal principal = getPrincipal();
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(habitController)
+                .setCustomArgumentResolvers(
+                        new PageableHandlerMethodArgumentResolver(),
+                        new UserArgumentResolver(userService, modelMapper))
+                .build();
+    }
+
+}

--- a/service-api/src/main/java/greencity/dto/PageableDto.java
+++ b/service-api/src/main/java/greencity/dto/PageableDto.java
@@ -2,10 +2,13 @@ package greencity.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class PageableDto<T> {
     private List<T> page;
 


### PR DESCRIPTION
Adds MockMvc unit tests for HabitController endpoints.

Covers:

Fetching habits by ID, tags, or parameters.

Retrieving shopping list items and friends’ profile pictures.

Adding a custom habit (valid and invalid requests).

Uses Mockito to mock services and ObjectMapper for JSON in multipart requests.

Includes positive and negative scenarios with validation and error handling.