### PR TITLE
BUGFIX: Add missing HTTP response codes to Swagger for checkNewsIsLikedByUser #16, #17, #82

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -368,6 +368,12 @@ public class EcoNewsController {
      * @return user liked news or not.
      */
     @Operation(summary = "Check if user liked news")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401",  description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404",  description = HttpStatuses.NOT_FOUND)
+    })
     @GetMapping("/isLikedByUser")
     public ResponseEntity<Boolean> checkNewsIsLikedByUser(@RequestParam("econewsId") Long econewsId,
                                                           @Parameter(hidden = true) @CurrentUser UserVO user) {


### PR DESCRIPTION
Added missing HTTP response codes (400, 401, 404) in the Swagger documentation for the checkNewsIsLikedByUser method in EcoNewsController.