### PR TITLE
Update EcoNews API: hide fields, fix form-data model, and add 415 response

### DIFF
--- a/core/src/main/java/greencity/constant/HttpStatuses.java
+++ b/core/src/main/java/greencity/constant/HttpStatuses.java
@@ -10,6 +10,7 @@ public final class HttpStatuses {
     public static final String NOT_FOUND = "Not Found";
     public static final String SEE_OTHER = "See Other";
     public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
+    public static final String UNSUPPORTED_MEDIA_TYPE = "Unsupported Media Type";
 
     HttpStatuses() {
     }

--- a/core/src/main/java/greencity/constant/SwaggerExampleModel.java
+++ b/core/src/main/java/greencity/constant/SwaggerExampleModel.java
@@ -15,18 +15,12 @@ public final class SwaggerExampleModel {
         + "\t<pre>\n";
 
     private static final String EXAMPLE =
-        "  \"image\": \"string\",\n"
-            + "  \"source\": \"https://example.org/\",\n"
-            + "  \"shortInfo\": \"string\",\n"
-            + "  \"tags\": [\n"
-            + "    \"string\"\n"
-            + "  ],\n"
-            + "  \"titleTranslation\":\n"
-            + "     {\"content\": \"string\",\n"
-            + "     \"languageCode\": \"string\"},\n"
-            + "  \"textTranslation\":\n"
-            + "     {\"content\": \"string\",\n"
-            + "     \"languageCode\": \"string\"}\n";
+            "  \"title\": \"string\",\n"
+                    + "  \"text\": \"stringstringstringst\",\n"
+                    + "  \"tags\": [\n"
+                    + "    \"string\"\n"
+                    + "  ],\n"
+                    + "  \"source\": \"string\"\n";
 
     private static final String AFTER_EXAMPLE = "\t</pre>\n"
         + "</div>";

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -66,6 +66,9 @@ public class EcoNewsController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
             content = @Content(schema = @Schema(implementation = EcoNewsGenericDto.class))),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401",  description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "415",  description = HttpStatuses.UNSUPPORTED_MEDIA_TYPE)
     })
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<EcoNewsGenericDto> save(

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -148,7 +148,8 @@ public class EcoNewsController {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK,
             content = @Content(schema = @Schema(implementation = EcoNewsGenericDto.class))),
         @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
-        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN)
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @PutMapping(path = "/update", consumes = {MediaType.APPLICATION_JSON_VALUE,
         MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/service-api/pom.xml
+++ b/service-api/pom.xml
@@ -123,5 +123,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.16.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+            <version>2.2.19</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service-api/src/main/java/greencity/dto/econews/AddEcoNewsDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/econews/AddEcoNewsDtoRequest.java
@@ -1,5 +1,6 @@
 package greencity.dto.econews;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
@@ -24,7 +25,9 @@ public class AddEcoNewsDtoRequest {
 
     private String source;
 
+    @Schema(hidden = true)
     private String image;
 
+    @Schema(hidden = true)
     private String shortInfo;
 }


### PR DESCRIPTION
- Added @Schema(hidden = true) to image and shortInfo in AddEcoNewsDtoRequest.
- Updated form-data model for POST /econews to only include tags, text, title, and source.
- Added 415 Unsupported Media Type to @ApiResponses alongside existing 400 Bad Request and 401 Unauthorized.