### PR TITLE
Finalize User Story View Events

### DIFF
--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -47,16 +47,16 @@ public class EventController {
      * @author Kateryna Holtvianska & Oleksandr Obydalo.
      */
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+        produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Create a new event")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
     })
     public ResponseEntity<EventDto> createEvent(
-            @RequestPart("addEventDtoRequest") @Valid AddEventDtoRequest addEventDtoRequest,
-            @RequestPart(value = "images", required = false) MultipartFile[] images,
-            @Parameter(hidden = true) @CurrentUser UserVO currentUser) throws IOException {
+        @RequestPart("addEventDtoRequest") @Valid AddEventDtoRequest addEventDtoRequest,
+        @RequestPart(value = "images", required = false) MultipartFile[] images,
+        @Parameter(hidden = true) @CurrentUser UserVO currentUser) throws IOException {
         validateUser(currentUser);
         validateEventRequest(addEventDtoRequest);
         validateImages(images);
@@ -74,8 +74,8 @@ public class EventController {
     @GetMapping("/visible")
     @Operation(summary = "Get events visible to the current user")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     public ResponseEntity<List<EventDto>> getVisibleEvents(@AuthenticationPrincipal UserVO user) {
         return ResponseEntity.ok(eventService.getVisibleEvents(user));
@@ -90,14 +90,14 @@ public class EventController {
      */
     @Operation(summary = "Delete event")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping(value = "/delete/{eventId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> deleteEvent(@PathVariable Long eventId,
-                                            @Parameter(hidden = true) @CurrentUser UserVO user) {
+        @Parameter(hidden = true) @CurrentUser UserVO user) {
         eventService.deleteEvent(eventId, user);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -148,13 +148,13 @@ public class EventController {
             throw new BadRequestException("Title length must not exceed 70 characters.");
         }
         if (addEventDtoRequest.getDescription() == null
-                || addEventDtoRequest.getDescription().length() < 20
-                || addEventDtoRequest.getDescription().length() > 63206) {
+            || addEventDtoRequest.getDescription().length() < 20
+            || addEventDtoRequest.getDescription().length() > 63206) {
             throw new BadRequestException("Description must be between 20 and 63,206 characters.");
         }
         if (addEventDtoRequest.getDatesLocations() == null
-                || addEventDtoRequest.getDatesLocations().isEmpty()
-                || addEventDtoRequest.getDatesLocations().size() > 7) {
+            || addEventDtoRequest.getDatesLocations().isEmpty()
+            || addEventDtoRequest.getDatesLocations().size() > 7) {
             throw new BadRequestException("Event must contain between 1 and 7 date/location entries.");
         }
     }
@@ -210,17 +210,21 @@ public class EventController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Get events that the authenticated user has joined")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
-            @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
+        @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public ResponseEntity<Page<EventPreviewDto>> getMyEvents(
-            @Parameter(hidden = true) @CurrentUser UserVO currentUser,
-            @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
-            @Parameter(description = "Filter by event type: ONLINE, PLACE, BOTH") @RequestParam(value = "eventType", required = false) EventType eventType,
-            @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status", required = false) String status,
-            @Parameter(description = "User latitude for distance-based sorting (for PLACE events)") @RequestParam(value = "userLatitude", required = false) Double userLatitude,
-            @Parameter(description = "User longitude for distance-based sorting (for PLACE events)") @RequestParam(value = "userLongitude", required = false) Double userLongitude) {
+        @Parameter(hidden = true) @CurrentUser UserVO currentUser,
+        @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
+        @Parameter(description = "Filter by event type: ONLINE, PLACE, BOTH") @RequestParam(value = "eventType",
+            required = false) EventType eventType,
+        @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status",
+            required = false) String status,
+        @Parameter(description = "User latitude for distance-based sorting (for PLACE events)") @RequestParam(
+            value = "userLatitude", required = false) Double userLatitude,
+        @Parameter(description = "User longitude for distance-based sorting (for PLACE events)") @RequestParam(
+            value = "userLongitude", required = false) Double userLongitude) {
         validateUser(currentUser);
 
         Page<EventPreviewDto> events = eventService.getMyEvents(
@@ -260,14 +264,15 @@ public class EventController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Get events created by the authenticated user")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
-            @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
+        @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public ResponseEntity<Page<EventPreviewDto>> getMyCreatedEvents(
-            @Parameter(hidden = true) @CurrentUser UserVO currentUser,
-            @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
-            @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status", required = false) String status) {
+        @Parameter(hidden = true) @CurrentUser UserVO currentUser,
+        @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
+        @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status",
+            required = false) String status) {
         validateUser(currentUser);
 
         Page<EventPreviewDto> events =
@@ -290,14 +295,15 @@ public class EventController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Get all events related to the authenticated user (created and joined)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
-            @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
+        @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public ResponseEntity<Page<EventPreviewDto>> getRelatedEvents(
-            @Parameter(hidden = true) @CurrentUser UserVO currentUser,
-            @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
-            @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status", required = false) String status) {
+        @Parameter(hidden = true) @CurrentUser UserVO currentUser,
+        @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
+        @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status",
+            required = false) String status) {
         validateUser(currentUser);
 
         Page<EventPreviewDto> events =
@@ -317,16 +323,16 @@ public class EventController {
     @DeleteMapping("/removeAttender/{eventId}")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Remove an attender from the event",
-            description = "Cancel attendance for an upcoming or live event. Cannot cancel attendance for passed events.")
+        description = "Cancel attendance for an upcoming or live event. Cannot cancel attendance for passed events.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully removed attender"),
-            @ApiResponse(responseCode = "400", description = "Bad request - event has passed or user is not an attender"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "404", description = "Event not found")
+        @ApiResponse(responseCode = "200", description = "Successfully removed attender"),
+        @ApiResponse(responseCode = "400", description = "Bad request - event has passed or user is not an attender"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "404", description = "Event not found")
     })
     public ResponseEntity<Map<String, Object>> removeAttender(
-            @Parameter(description = "Event ID") @PathVariable Long eventId,
-            @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
+        @Parameter(description = "Event ID") @PathVariable Long eventId,
+        @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
         validateUser(currentUser);
 
         boolean removed = eventService.removeAttender(eventId, currentUser);
@@ -349,14 +355,14 @@ public class EventController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Add an attender to the event")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     public ResponseEntity<Map<String, Object>> addAttender(
-            @PathVariable Long eventId,
-            @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
+        @PathVariable Long eventId,
+        @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
         validateUser(currentUser);
 
         boolean added = eventService.addAttender(eventId, currentUser);

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -50,7 +50,7 @@ public class EventController {
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Create a new event")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
     })
     public ResponseEntity<EventDto> createEvent(

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -48,16 +48,16 @@ public class EventController {
      * @author Kateryna Holtvianska & Oleksandr Obydalo.
      */
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Create a new event")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
     })
     public ResponseEntity<EventDto> createEvent(
-        @RequestPart("addEventDtoRequest") @Valid AddEventDtoRequest addEventDtoRequest,
-        @RequestPart(value = "images", required = false) MultipartFile[] images,
-        @Parameter(hidden = true) @CurrentUser UserVO currentUser) throws IOException {
+            @RequestPart("addEventDtoRequest") @Valid AddEventDtoRequest addEventDtoRequest,
+            @RequestPart(value = "images", required = false) MultipartFile[] images,
+            @Parameter(hidden = true) @CurrentUser UserVO currentUser) throws IOException {
         validateUser(currentUser);
         validateEventRequest(addEventDtoRequest);
         validateImages(images);
@@ -69,8 +69,8 @@ public class EventController {
     @GetMapping("/visible")
     @Operation(summary = "Get events visible to the current user")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     public ResponseEntity<List<EventDto>> getVisibleEvents(@AuthenticationPrincipal UserVO user) {
         return ResponseEntity.ok(eventService.getVisibleEvents(user));
@@ -85,14 +85,14 @@ public class EventController {
      */
     @Operation(summary = "Delete event")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping(value = "/delete/{eventId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> deleteEvent(@PathVariable Long eventId,
-        @Parameter(hidden = true) @CurrentUser UserVO user) {
+                                            @Parameter(hidden = true) @CurrentUser UserVO user) {
         eventService.deleteEvent(eventId, user);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -111,13 +111,13 @@ public class EventController {
             throw new BadRequestException("Title length must not exceed 70 characters.");
         }
         if (addEventDtoRequest.getDescription() == null
-            || addEventDtoRequest.getDescription().length() < 20
-            || addEventDtoRequest.getDescription().length() > 63206) {
+                || addEventDtoRequest.getDescription().length() < 20
+                || addEventDtoRequest.getDescription().length() > 63206) {
             throw new BadRequestException("Description must be between 20 and 63,206 characters.");
         }
         if (addEventDtoRequest.getDatesLocations() == null
-            || addEventDtoRequest.getDatesLocations().isEmpty()
-            || addEventDtoRequest.getDatesLocations().size() > 7) {
+                || addEventDtoRequest.getDatesLocations().isEmpty()
+                || addEventDtoRequest.getDatesLocations().size() > 7) {
             throw new BadRequestException("Event must contain between 1 and 7 date/location entries.");
         }
     }
@@ -171,13 +171,19 @@ public class EventController {
      */
     @GetMapping("/myEvents")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Get events that the authenticated user has joined")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
+            @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
     public ResponseEntity<Page<EventPreviewDto>> getMyEvents(
             @Parameter(hidden = true) @CurrentUser UserVO currentUser,
             @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
-            @RequestParam(value = "eventType", required = false) EventType eventType,
-            @RequestParam(value = "status", required = false) String status,
-            @RequestParam(value = "userLatitude", required = false) Double userLatitude,
-            @RequestParam(value = "userLongitude", required = false) Double userLongitude) {
+            @Parameter(description = "Filter by event type: ONLINE, PLACE, BOTH") @RequestParam(value = "eventType", required = false) EventType eventType,
+            @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status", required = false) String status,
+            @Parameter(description = "User latitude for distance-based sorting (for PLACE events)") @RequestParam(value = "userLatitude", required = false) Double userLatitude,
+            @Parameter(description = "User longitude for distance-based sorting (for PLACE events)") @RequestParam(value = "userLongitude", required = false) Double userLongitude) {
         validateUser(currentUser);
 
         Page<EventPreviewDto> events = eventService.getMyEvents(
@@ -199,10 +205,16 @@ public class EventController {
 
     @GetMapping("/myEvents/createdEvents")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Get events created by the authenticated user")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
+            @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
     public ResponseEntity<Page<EventPreviewDto>> getMyCreatedEvents(
             @Parameter(hidden = true) @CurrentUser UserVO currentUser,
             @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
-            @RequestParam(value = "status", required = false) String status) {
+            @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status", required = false) String status) {
         validateUser(currentUser);
 
         Page<EventPreviewDto> events = eventService.getMyCreatedEvents(currentUser.getId(), parseEventStatus(status), pageable);
@@ -222,10 +234,16 @@ public class EventController {
      */
     @GetMapping("/myEvents/relatedEvents")
     @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Get all events related to the authenticated user (created and joined)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved events"),
+            @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
     public ResponseEntity<Page<EventPreviewDto>> getRelatedEvents(
             @Parameter(hidden = true) @CurrentUser UserVO currentUser,
             @Parameter(hidden = true) @PageableDefault(size = 10) Pageable pageable,
-            @RequestParam(value = "status", required = false) String status) {
+            @Parameter(description = "Filter by status: UPCOMING, LIVE, PASSED") @RequestParam(value = "status", required = false) String status) {
         validateUser(currentUser);
 
         Page<EventPreviewDto> events = eventService.getRelatedEvents(currentUser.getId(), parseEventStatus(status), pageable);
@@ -243,16 +261,17 @@ public class EventController {
      */
     @DeleteMapping("/removeAttender/{eventId}")
     @PreAuthorize("isAuthenticated()")
-    @Operation(summary = "Remove an attender from the event")
+    @Operation(summary = "Remove an attender from the event",
+            description = "Cancel attendance for an upcoming or live event. Cannot cancel attendance for passed events.")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = "Successfully removed attender"),
+            @ApiResponse(responseCode = "400", description = "Bad request - event has passed or user is not an attender"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Event not found")
     })
     public ResponseEntity<Map<String, Object>> removeAttender(
-        @PathVariable Long eventId,
-        @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
+            @Parameter(description = "Event ID") @PathVariable Long eventId,
+            @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
         validateUser(currentUser);
 
         boolean removed = eventService.removeAttender(eventId, currentUser);
@@ -275,14 +294,14 @@ public class EventController {
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Add an attender to the event")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
-        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     public ResponseEntity<Map<String, Object>> addAttender(
-        @PathVariable Long eventId,
-        @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
+            @PathVariable Long eventId,
+            @Parameter(hidden = true) @CurrentUser UserVO currentUser) {
         validateUser(currentUser);
 
         boolean added = eventService.addAttender(eventId, currentUser);

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -64,25 +64,25 @@ class EventControllerTest {
     MockMvc mockMvc;
 
     ObjectMapper objectMapper = new ObjectMapper()
-        .registerModule(new JavaTimeModule())
-        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            .registerModule(new JavaTimeModule())
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     private static final String EVENT_NOT_FOUND_MESSAGE_PREFIX = "Event doesn't exist by this id: ";
     private static final String USER_NO_PERMISSION_MESSAGE = "Current user has no permission for this action";
 
     // Mock the authenticated user
     UserVO mockUser = UserVO.builder()
-        .id(5L)
-        .email("test@example.com")
-        .name("Test User")
-        .build();
+            .id(5L)
+            .email("test@example.com")
+            .name("Test User")
+            .build();
 
     static class ForcedMessageErrorAttributes extends DefaultErrorAttributes {
         @Override
         public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
             ErrorAttributeOptions newOptions = options.including(
-                ErrorAttributeOptions.Include.MESSAGE,
-                ErrorAttributeOptions.Include.EXCEPTION);
+                    ErrorAttributeOptions.Include.MESSAGE,
+                    ErrorAttributeOptions.Include.EXCEPTION);
             return super.getErrorAttributes(webRequest, newOptions);
         }
     }
@@ -98,31 +98,31 @@ class EventControllerTest {
         @Override
         public boolean supportsParameter(MethodParameter parameter) {
             return parameter.getParameterAnnotation(CurrentUser.class) != null
-                && parameter.getParameterType().equals(UserVO.class);
+                    && parameter.getParameterType().equals(UserVO.class);
         }
 
         @Override
         public Object resolveArgument(MethodParameter parameter,
-            ModelAndViewContainer mavContainer,
-            NativeWebRequest webRequest,
-            WebDataBinderFactory binderFactory) throws Exception {
+                                      ModelAndViewContainer mavContainer,
+                                      NativeWebRequest webRequest,
+                                      WebDataBinderFactory binderFactory) throws Exception {
             return userVO;
         }
     }
 
     EventDateLocationDto locationDto = EventDateLocationDto.builder()
-        .startDate(OffsetDateTime.now().plusDays(2))
-        .finishDate(OffsetDateTime.now().plusDays(2).plusHours(3))
-        .latitude(50.45)
-        .longitude(30.52)
-        .build();
+            .startDate(OffsetDateTime.now().plusDays(2))
+            .finishDate(OffsetDateTime.now().plusDays(2).plusHours(3))
+            .latitude(50.45)
+            .longitude(30.52)
+            .build();
 
     AddEventDtoRequest addEventDtoRequest = AddEventDtoRequest.builder()
-        .title("Eco Cleanup")
-        .description("Let's clean the park together for a better future!")
-        .open(true)
-        .datesLocations(List.of(locationDto))
-        .build();
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .datesLocations(List.of(locationDto))
+            .build();
 
     @BeforeEach
     void setup() {
@@ -130,10 +130,10 @@ class EventControllerTest {
 
         CustomExceptionHandler exceptionHandler = new CustomExceptionHandler(errorAttributes, objectMapper);
         mockMvc = MockMvcBuilders.standaloneSetup(eventController)
-            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                new TestUserArgumentResolver(mockUser))
-            .setControllerAdvice(exceptionHandler)
-            .build();
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                        new TestUserArgumentResolver(mockUser))
+                .setControllerAdvice(exceptionHandler)
+                .build();
     }
 
     private byte[] createValidJpegBytes() {
@@ -166,110 +166,110 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile image = new MockMultipartFile(
-            "images",
-            "test.jpg",
-            MediaType.IMAGE_JPEG_VALUE,
-            createValidJpegBytes());
+                "images",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                createValidJpegBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-            .id(1L)
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("event-1-uuid.jpg")
-            .imageUrls(List.of("event-1-uuid.jpg"))
-            .datesLocations(List.of(locationDto))
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .id(1L)
+                .title("Eco Cleanup")
+                .description("Let's clean the park together for a better future!")
+                .open(true)
+                .organizerId(5L)
+                .titleImage("event-1-uuid.jpg")
+                .imageUrls(List.of("event-1-uuid.jpg"))
+                .datesLocations(List.of(locationDto))
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-            .thenReturn(responseDto);
+                .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.title").value("Eco Cleanup"))
-            .andExpect(jsonPath("$.organizerId").value(5))
-            .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.jpg"));
+                        .file(dtoPart)
+                        .file(image)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.title").value("Eco Cleanup"))
+                .andExpect(jsonPath("$.organizerId").value(5))
+                .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.jpg"));
     }
 
     @Test
     void createEvent_ShouldReturn400BadRequest() throws Exception {
         AddEventDtoRequest invalidDto = AddEventDtoRequest.builder()
-            .title("")
-            .description("Too short")
-            .open(true)
-            .datesLocations(List.of(locationDto))
-            .build();
+                .title("")
+                .description("Too short")
+                .open(true)
+                .datesLocations(List.of(locationDto))
+                .build();
 
         String json = objectMapper.writeValueAsString(invalidDto);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         MockMultipartFile image = new MockMultipartFile(
-            "images",
-            "test.jpg",
-            MediaType.IMAGE_JPEG_VALUE,
-            createValidJpegBytes());
+                "images",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                createValidJpegBytes());
 
         when(eventService.createEvent(any(), any(), anyLong()))
-            .thenThrow(new BadRequestException("Title must be between 1 and 70 characters"));
+                .thenThrow(new BadRequestException("Title must be between 1 and 70 characters"));
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(dtoPart)
+                        .file(image)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     void getVisibleEvents_ShouldReturn200() throws Exception {
         EventDto openEvent = EventDto.builder()
-            .id(1L)
-            .title("Public Cleanup")
-            .description("Open event for everyone")
-            .open(true)
-            .organizerId(3L)
-            .build();
+                .id(1L)
+                .title("Public Cleanup")
+                .description("Open event for everyone")
+                .open(true)
+                .organizerId(3L)
+                .build();
 
         EventDto friendEvent = EventDto.builder()
-            .id(2L)
-            .title("Recycling Workshop")
-            .description("Learn how to recycle effectively at home.")
-            .open(false)
-            .organizerId(2L)
-            .build();
+                .id(2L)
+                .title("Recycling Workshop")
+                .description("Learn how to recycle effectively at home.")
+                .open(false)
+                .organizerId(2L)
+                .build();
 
         List<EventDto> visibleEvents = List.of(openEvent, friendEvent);
 
         when(eventService.getVisibleEvents(any(UserVO.class))).thenReturn(visibleEvents);
 
         mockMvc.perform(get("/events/visible")
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$", hasSize(2)))
-            .andExpect(jsonPath("$[0].title").value("Public Cleanup"))
-            .andExpect(jsonPath("$[0].open").value(true))
-            .andExpect(jsonPath("$[1].title").value("Recycling Workshop"))
-            .andExpect(jsonPath("$[1].open").value(false));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].title").value("Public Cleanup"))
+                .andExpect(jsonPath("$[0].open").value(true))
+                .andExpect(jsonPath("$[1].title").value("Recycling Workshop"))
+                .andExpect(jsonPath("$[1].open").value(false));
     }
 
     @Test
@@ -278,23 +278,23 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile image = new MockMultipartFile(
-            "images",
-            "test.gif",
-            MediaType.IMAGE_GIF_VALUE,
-            "fake-image-content".getBytes());
+                "images",
+                "test.gif",
+                MediaType.IMAGE_GIF_VALUE,
+                "fake-image-content".getBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(dtoPart)
+                        .file(image)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -303,39 +303,39 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile image = new MockMultipartFile(
-            "images",
-            "test.png",
-            MediaType.IMAGE_PNG_VALUE,
-            createValidPngBytes());
+                "images",
+                "test.png",
+                MediaType.IMAGE_PNG_VALUE,
+                createValidPngBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-            .id(1L)
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("event-1-uuid.png")
-            .imageUrls(List.of("event-1-uuid.png"))
-            .datesLocations(List.of(locationDto))
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .id(1L)
+                .title("Eco Cleanup")
+                .description("Let's clean the park together for a better future!")
+                .open(true)
+                .organizerId(5L)
+                .titleImage("event-1-uuid.png")
+                .imageUrls(List.of("event-1-uuid.png"))
+                .datesLocations(List.of(locationDto))
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-            .thenReturn(responseDto);
+                .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.png"));
+                        .file(dtoPart)
+                        .file(image)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.png"));
     }
 
     @Test
@@ -346,23 +346,23 @@ class EventControllerTest {
         // Create a file larger than 10MB
         byte[] largeContent = createValidJpegBytes(11 * 1024 * 1024); // 11MB
         MockMultipartFile oversizedImage = new MockMultipartFile(
-            "images",
-            "large.jpg",
-            MediaType.IMAGE_JPEG_VALUE,
-            largeContent);
+                "images",
+                "large.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                largeContent);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(oversizedImage)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(dtoPart)
+                        .file(oversizedImage)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -373,38 +373,38 @@ class EventControllerTest {
         // Create a file exactly 10MB
         byte[] exactContent = createValidJpegBytes(10 * 1024 * 1024); // Exactly 10MB
         MockMultipartFile exactSizeImage = new MockMultipartFile(
-            "images",
-            "exact.jpg",
-            MediaType.IMAGE_JPEG_VALUE,
-            exactContent);
+                "images",
+                "exact.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                exactContent);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-            .id(1L)
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("event-1-uuid.jpg")
-            .imageUrls(List.of("event-1-uuid.jpg"))
-            .datesLocations(List.of(locationDto))
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .id(1L)
+                .title("Eco Cleanup")
+                .description("Let's clean the park together for a better future!")
+                .open(true)
+                .organizerId(5L)
+                .titleImage("event-1-uuid.jpg")
+                .imageUrls(List.of("event-1-uuid.jpg"))
+                .datesLocations(List.of(locationDto))
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-            .thenReturn(responseDto);
+                .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(exactSizeImage)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated());
+                        .file(dtoPart)
+                        .file(exactSizeImage)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
     }
 
     @Test
@@ -413,36 +413,36 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         // Create 6 images
         MockMultipartFile image1 =
-            new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image2 =
-            new MockMultipartFile("images", "test2.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test2.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image3 =
-            new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image4 =
-            new MockMultipartFile("images", "test4.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test4.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image5 =
-            new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image6 =
-            new MockMultipartFile("images", "test6.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test6.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image1)
-            .file(image2)
-            .file(image3)
-            .file(image4)
-            .file(image5)
-            .file(image6)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(dtoPart)
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .file(image4)
+                        .file(image5)
+                        .file(image6)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -451,51 +451,51 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         // Create exactly 5 images (3 JPEG, 2 PNG)
         MockMultipartFile image1 =
-            new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image2 =
-            new MockMultipartFile("images", "test2.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
+                new MockMultipartFile("images", "test2.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
         MockMultipartFile image3 =
-            new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image4 =
-            new MockMultipartFile("images", "test4.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
+                new MockMultipartFile("images", "test4.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
         MockMultipartFile image5 =
-            new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
 
         EventDto responseDto = EventDto.builder()
-            .id(1L)
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("event-1-uuid1.jpg")
-            .imageUrls(List.of("event-1-uuid1.jpg", "event-1-uuid2.png", "event-1-uuid3.jpg", "event-1-uuid4.png",
-                "event-1-uuid5.jpg"))
-            .datesLocations(List.of(locationDto))
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .id(1L)
+                .title("Eco Cleanup")
+                .description("Let's clean the park together for a better future!")
+                .open(true)
+                .organizerId(5L)
+                .titleImage("event-1-uuid1.jpg")
+                .imageUrls(List.of("event-1-uuid1.jpg", "event-1-uuid2.png", "event-1-uuid3.jpg", "event-1-uuid4.png",
+                        "event-1-uuid5.jpg"))
+                .datesLocations(List.of(locationDto))
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-            .thenReturn(responseDto);
+                .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image1)
-            .file(image2)
-            .file(image3)
-            .file(image4)
-            .file(image5)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.imageUrls.length()").value(5))
-            .andExpect(jsonPath("$.titleImage").value("event-1-uuid1.jpg"));
+                        .file(dtoPart)
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .file(image4)
+                        .file(image5)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.imageUrls.length()").value(5))
+                .andExpect(jsonPath("$.titleImage").value("event-1-uuid1.jpg"));
     }
 
     @Test
@@ -504,33 +504,33 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-            .id(1L)
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("default-event-image.jpg")
-            .imageUrls(List.of("default-event-image.jpg"))
-            .datesLocations(List.of(locationDto))
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .id(1L)
+                .title("Eco Cleanup")
+                .description("Let's clean the park together for a better future!")
+                .open(true)
+                .organizerId(5L)
+                .titleImage("default-event-image.jpg")
+                .imageUrls(List.of("default-event-image.jpg"))
+                .datesLocations(List.of(locationDto))
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(), eq(5L)))
-            .thenReturn(responseDto);
+                .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.titleImage").value("default-event-image.jpg"))
-            .andExpect(jsonPath("$.imageUrls[0]").value("default-event-image.jpg"));
+                        .file(dtoPart)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.titleImage").value("default-event-image.jpg"))
+                .andExpect(jsonPath("$.imageUrls[0]").value("default-event-image.jpg"));
     }
 
     @Test
@@ -539,44 +539,44 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         MockMultipartFile image1 =
-            new MockMultipartFile("images", "first.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "first.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image2 =
-            new MockMultipartFile("images", "second.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
+                new MockMultipartFile("images", "second.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
         MockMultipartFile image3 =
-            new MockMultipartFile("images", "third.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "third.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
 
         EventDto responseDto = EventDto.builder()
-            .id(1L)
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("event-1-first.jpg") // First image becomes main
-            .imageUrls(List.of("event-1-first.jpg", "event-1-second.png", "event-1-third.jpg"))
-            .datesLocations(List.of(locationDto))
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .id(1L)
+                .title("Eco Cleanup")
+                .description("Let's clean the park together for a better future!")
+                .open(true)
+                .organizerId(5L)
+                .titleImage("event-1-first.jpg") // First image becomes main
+                .imageUrls(List.of("event-1-first.jpg", "event-1-second.png", "event-1-third.jpg"))
+                .datesLocations(List.of(locationDto))
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-            .thenReturn(responseDto);
+                .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(image1)
-            .file(image2)
-            .file(image3)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.titleImage").value("event-1-first.jpg"))
-            .andExpect(jsonPath("$.imageUrls[0]").value("event-1-first.jpg"))
-            .andExpect(jsonPath("$.imageUrls.length()").value(3));
+                        .file(dtoPart)
+                        .file(image1)
+                        .file(image2)
+                        .file(image3)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.titleImage").value("event-1-first.jpg"))
+                .andExpect(jsonPath("$.imageUrls[0]").value("event-1-first.jpg"))
+                .andExpect(jsonPath("$.imageUrls.length()").value(3));
     }
 
     @Test
@@ -585,23 +585,23 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile imageWithoutContentType = new MockMultipartFile(
-            "images",
-            "test.jpg",
-            null, // No content type
-            "fake-content".getBytes());
+                "images",
+                "test.jpg",
+                null, // No content type
+                "fake-content".getBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(imageWithoutContentType)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(dtoPart)
+                        .file(imageWithoutContentType)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -610,47 +610,44 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-            "addEventDtoRequest",
-            "",
-            MediaType.APPLICATION_JSON_VALUE,
-            json.getBytes());
+                "addEventDtoRequest",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                json.getBytes());
 
         MockMultipartFile validImage =
-            new MockMultipartFile("images", "valid.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+                new MockMultipartFile("images", "valid.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile invalidImage =
-            new MockMultipartFile("images", "invalid.bmp", "image/bmp", "invalid-content".getBytes());
+                new MockMultipartFile("images", "invalid.bmp", "image/bmp", "invalid-content".getBytes());
 
         mockMvc.perform(multipart("/events/create")
-            .file(dtoPart)
-            .file(validImage)
-            .file(invalidImage)
-            .contentType(MediaType.MULTIPART_FORM_DATA)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                        .file(dtoPart)
+                        .file(validImage)
+                        .file(invalidImage)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
     void getMyEvents_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-            .id(1L)
-            .title("Test Event")
-            .description("Test Description")
-            .open(true)
-            .organizerId(1L)
-            .titleImage("test-image.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(1))
-            .canCancelJoin(true)
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(1L)
+                .title("Test Event")
+                .titleImage("test-image.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(false)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(false)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -658,38 +655,35 @@ class EventControllerTest {
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents")
-            .param("eventType", "BOTH")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content[0].id").value(1))
-            .andExpect(jsonPath("$.content[0].title").value("Test Event"))
-            .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
-            .andExpect(jsonPath("$.totalElements").value(1));
+                        .param("eventType", "BOTH")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("Test Event"))
+                .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
+                .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getMyEventsWithCoordinates_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-            .id(1L)
-            .title("Test Event")
-            .description("Test Description")
-            .open(true)
-            .organizerId(1L)
-            .titleImage("test-image.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(1))
-            .canCancelJoin(true)
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(1L)
+                .title("Test Event")
+                .titleImage("test-image.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(1.23)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(false)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(false)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -697,40 +691,37 @@ class EventControllerTest {
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents")
-            .param("eventType", "PLACE")
-            .param("userLatitude", "50.45")
-            .param("userLongitude", "30.52")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content[0].id").value(1))
-            .andExpect(jsonPath("$.content[0].title").value("Test Event"))
-            .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
-            .andExpect(jsonPath("$.totalElements").value(1));
+                        .param("eventType", "PLACE")
+                        .param("userLatitude", "50.45")
+                        .param("userLongitude", "30.52")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("Test Event"))
+                .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
+                .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getMyEventsWithOnlineTypeNoCoordinates_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-            .id(1L)
-            .title("Online Event")
-            .description("Test Online Event")
-            .open(true)
-            .organizerId(1L)
-            .titleImage("online-event.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(1))
-            .canCancelJoin(true)
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(null)
-            .longitude(null)
-            .onlineLink("https://example.com/meeting")
-            .build();
+                .id(1L)
+                .title("Online Event")
+                .titleImage("online-event.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(3))
+                .types(greencity.dto.event.EventTypesDto.builder().place(false).online(true).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(false)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(false)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -738,39 +729,34 @@ class EventControllerTest {
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents")
-            .param("eventType", "ONLINE")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content[0].id").value(1))
-            .andExpect(jsonPath("$.content[0].title").value("Online Event"))
-            .andExpect(jsonPath("$.content[0].onlineLink").value("https://example.com/meeting"))
-            .andExpect(jsonPath("$.totalElements").value(1));
+                        .param("eventType", "ONLINE")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("Online Event"))
+                .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getMyCreatedEvents_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-            .id(1L)
-            .title("My Created Event")
-            .description("Event I created")
-            .open(true)
-            .organizerId(5L) // Same as current user
-            .titleImage("my-event-image.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(1))
-            .canCancelJoin(true)
-            .canEdit(true) // Should be true for organizer
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(1L)
+                .title("My Created Event")
+                .titleImage("my-event-image.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(true)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(true)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -778,15 +764,15 @@ class EventControllerTest {
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/createdEvents")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content[0].id").value(1))
-            .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
-            .andExpect(jsonPath("$.content[0].organizerId").value(5))
-            .andExpect(jsonPath("$.content[0].canEdit").value(true))
-            .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
-            .andExpect(jsonPath("$.totalElements").value(1));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
+                // unified DTO no longer exposes organizerId
+                .andExpect(jsonPath("$.content[0].canEdit").value(true))
+                .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
+                .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
@@ -796,7 +782,7 @@ class EventControllerTest {
         doNothing().when(eventService).deleteEvent(eventId, mockUser);
 
         mockMvc.perform(delete("/events/delete/{eventId}", eventId))
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
 
         verify(eventService).deleteEvent(eventId, mockUser);
     }
@@ -807,12 +793,12 @@ class EventControllerTest {
         String errorMessage = USER_NO_PERMISSION_MESSAGE;
 
         doThrow(new UnauthorizedException(errorMessage))
-            .when(eventService).deleteEvent(eventId, mockUser);
+                .when(eventService).deleteEvent(eventId, mockUser);
 
         mockMvc.perform(delete("/events/delete/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.message").value(errorMessage));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -821,12 +807,12 @@ class EventControllerTest {
         String errorMessage = EVENT_NOT_FOUND_MESSAGE_PREFIX + eventId;
 
         doThrow(new NotFoundException(errorMessage))
-            .when(eventService).deleteEvent(eventId, mockUser);
+                .when(eventService).deleteEvent(eventId, mockUser);
 
         mockMvc.perform(delete("/events/delete/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value(errorMessage));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -836,9 +822,9 @@ class EventControllerTest {
         when(eventService.removeAttender(eventId, mockUser)).thenReturn(true);
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.removed").value(true));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.removed").value(true));
 
         verify(eventService).removeAttender(eventId, mockUser);
     }
@@ -850,9 +836,9 @@ class EventControllerTest {
         when(eventService.removeAttender(eventId, mockUser)).thenReturn(false);
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.removed").value(false));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.removed").value(false));
 
         verify(eventService).removeAttender(eventId, mockUser);
     }
@@ -863,12 +849,12 @@ class EventControllerTest {
         String errorMessage = EVENT_NOT_FOUND_MESSAGE_PREFIX + eventId;
 
         when(eventService.removeAttender(eventId, mockUser))
-            .thenThrow(new NotFoundException(errorMessage));
+                .thenThrow(new NotFoundException(errorMessage));
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value(errorMessage));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -877,12 +863,12 @@ class EventControllerTest {
         String errorMessage = "Cannot cancel attendance for events that have already passed";
 
         when(eventService.removeAttender(eventId, mockUser))
-            .thenThrow(new BadRequestException(errorMessage));
+                .thenThrow(new BadRequestException(errorMessage));
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.message").value(errorMessage));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -892,9 +878,9 @@ class EventControllerTest {
         when(eventService.addAttender(eventId, mockUser)).thenReturn(true);
 
         mockMvc.perform(post("/events/addAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.added").value(true));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.added").value(true));
 
         verify(eventService).addAttender(eventId, mockUser);
     }
@@ -906,9 +892,9 @@ class EventControllerTest {
         when(eventService.addAttender(eventId, mockUser)).thenReturn(false);
 
         mockMvc.perform(post("/events/addAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.added").value(false));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.added").value(false));
 
         verify(eventService).addAttender(eventId, mockUser);
     }
@@ -919,37 +905,33 @@ class EventControllerTest {
         String errorMessage = EVENT_NOT_FOUND_MESSAGE_PREFIX + eventId;
 
         when(eventService.addAttender(eventId, mockUser))
-            .thenThrow(new NotFoundException(errorMessage));
+                .thenThrow(new NotFoundException(errorMessage));
 
         mockMvc.perform(post("/events/addAttender/{eventId}", eventId)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value(errorMessage));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
     public void getMyCreatedEvents_ShouldReturnPassedEvents() throws Exception {
 
         EventPreviewDto passedEvent = EventPreviewDto.builder()
-            .id(2L)
-            .title("Past Event")
-            .description("Event that already happened")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("past-event-image.jpg")
-            .createdAt(OffsetDateTime.now().minusDays(10))
-            .updatedAt(OffsetDateTime.now().minusDays(10))
-            .status(EventStatus.PASSED)
-            .nearestStart(OffsetDateTime.now().minusDays(5))
-            .canCancelJoin(false)
-            .canEdit(true) // Should still be true for organizer
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(2L)
+                .title("Past Event")
+                .titleImage("past-event-image.jpg")
+                .status(EventStatus.PASSED)
+                .nearestStart(OffsetDateTime.now().minusDays(5))
+                .nearestFinish(OffsetDateTime.now().minusDays(4))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(false)
+                .canEdit(true)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(true)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(passedEvent), PageRequest.of(0, 10), 1);
 
@@ -957,136 +939,124 @@ class EventControllerTest {
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/createdEvents")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content[0].id").value(2))
-            .andExpect(jsonPath("$.content[0].title").value("Past Event"))
-            .andExpect(jsonPath("$.content[0].status").value("PASSED"))
-            .andExpect(jsonPath("$.content[0].canEdit").value(true))
-            .andExpect(jsonPath("$.totalElements").value(1));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].id").value(2))
+                .andExpect(jsonPath("$.content[0].title").value("Past Event"))
+                .andExpect(jsonPath("$.content[0].status").value("PASSED"))
+                .andExpect(jsonPath("$.content[0].canEdit").value(true))
+                .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getRelatedEvents_ShouldReturn200Ok() throws Exception {
         // Create test events - mix of created and joined events
         EventPreviewDto createdEvent = EventPreviewDto.builder()
-            .id(1L)
-            .title("My Created Event")
-            .description("Event I created")
-            .open(true)
-            .organizerId(5L) // Same as current user
-            .titleImage("created-event.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(1))
-            .canCancelJoin(true)
-            .canEdit(true) // Should be true for organizer
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(1L)
+                .title("My Created Event")
+                .titleImage("created-event.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(true)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(true)
+                .build();
 
         EventPreviewDto joinedEvent = EventPreviewDto.builder()
-            .id(2L)
-            .title("Joined Event")
-            .description("Event I joined")
-            .open(true)
-            .organizerId(10L) // Different organizer
-            .titleImage("joined-event.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(2))
-            .canCancelJoin(true)
-            .canEdit(false) // Should be false for non-organizer
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(2L)
+                .title("Joined Event")
+                .titleImage("joined-event.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(2))
+                .nearestFinish(OffsetDateTime.now().plusDays(2).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(false)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(false)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(
-            List.of(createdEvent, joinedEvent), PageRequest.of(0, 10), 2);
+                List.of(createdEvent, joinedEvent), PageRequest.of(0, 10), 2);
 
         when(eventService.getRelatedEvents(eq(5L), eq(null), any(Pageable.class)))
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/relatedEvents")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content", hasSize(2)))
-            .andExpect(jsonPath("$.content[0].id").value(1))
-            .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
-            .andExpect(jsonPath("$.content[0].canEdit").value(true))
-            .andExpect(jsonPath("$.content[1].id").value(2))
-            .andExpect(jsonPath("$.content[1].title").value("Joined Event"))
-            .andExpect(jsonPath("$.content[1].canEdit").value(false))
-            .andExpect(jsonPath("$.totalElements").value(2));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
+                .andExpect(jsonPath("$.content[0].canEdit").value(true))
+                .andExpect(jsonPath("$.content[1].id").value(2))
+                .andExpect(jsonPath("$.content[1].title").value("Joined Event"))
+                .andExpect(jsonPath("$.content[1].canEdit").value(false))
+                .andExpect(jsonPath("$.totalElements").value(2));
     }
 
     @Test
     void getRelatedEvents_WithPagination_ShouldReturn200Ok() throws Exception {
         EventPreviewDto event = EventPreviewDto.builder()
-            .id(1L)
-            .title("Related Event")
-            .description("Test Event")
-            .open(true)
-            .organizerId(5L)
-            .titleImage("event.jpg")
-            .createdAt(OffsetDateTime.now())
-            .updatedAt(OffsetDateTime.now())
-            .status(EventStatus.UPCOMING)
-            .nearestStart(OffsetDateTime.now().plusDays(1))
-            .canCancelJoin(true)
-            .canEdit(true)
-            .isFavourite(false)
-            .isSubscribed(false)
-            .visibility("PUBLIC")
-            .latitude(50.45)
-            .longitude(30.52)
-            .onlineLink(null)
-            .build();
+                .id(1L)
+                .title("Related Event")
+                .titleImage("event.jpg")
+                .status(EventStatus.UPCOMING)
+                .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
+                .canCancelJoin(true)
+                .canEdit(true)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(true)
+                .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(
-            List.of(event), PageRequest.of(0, 5), 1);
+                List.of(event), PageRequest.of(0, 5), 1);
 
         when(eventService.getRelatedEvents(eq(5L), eq(null), any(Pageable.class)))
                 .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/relatedEvents")
-            .param("page", "0")
-            .param("size", "5")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content", hasSize(1)))
-            .andExpect(jsonPath("$.totalElements").value(1))
-            .andExpect(jsonPath("$.size").value(5))
-            .andExpect(jsonPath("$.number").value(0));
+                        .param("page", "0")
+                        .param("size", "5")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.size").value(5))
+                .andExpect(jsonPath("$.number").value(0));
     }
 
     @Test
     void getRelatedEvents_EmptyResult_ShouldReturn200Ok() throws Exception {
         Page<EventPreviewDto> emptyPage = new PageImpl<>(
-            List.of(), PageRequest.of(0, 10), 0);
+                List.of(), PageRequest.of(0, 10), 0);
 
         when(eventService.getRelatedEvents(eq(5L), eq(null), any(Pageable.class)))
                 .thenReturn(emptyPage);
 
         mockMvc.perform(get("/events/myEvents/relatedEvents")
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.content", hasSize(0)))
-            .andExpect(jsonPath("$.totalElements").value(0));
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.totalElements").value(0));
     }
 
     @Test
@@ -1094,22 +1064,18 @@ class EventControllerTest {
         EventPreviewDto upcomingEvent = EventPreviewDto.builder()
                 .id(1L)
                 .title("Upcoming Event")
-                .description("Test Description")
-                .open(true)
-                .organizerId(1L)
                 .titleImage("test-image.jpg")
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
                 .status(EventStatus.UPCOMING)
                 .nearestStart(OffsetDateTime.now().plusDays(1))
+                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
                 .canCancelJoin(true)
                 .canEdit(false)
                 .isFavourite(false)
                 .isSubscribed(false)
-                .visibility("PUBLIC")
-                .latitude(50.45)
-                .longitude(30.52)
-                .onlineLink(null)
+                .isOrganizer(false)
                 .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(upcomingEvent), PageRequest.of(0, 10), 1);
@@ -1131,22 +1097,18 @@ class EventControllerTest {
         EventPreviewDto liveEvent = EventPreviewDto.builder()
                 .id(2L)
                 .title("Live Event")
-                .description("Currently happening")
-                .open(true)
-                .organizerId(5L)
                 .titleImage("live-image.jpg")
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
                 .status(EventStatus.LIVE)
                 .nearestStart(OffsetDateTime.now().minusHours(1))
+                .nearestFinish(OffsetDateTime.now().plusHours(1))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
                 .canCancelJoin(false)
                 .canEdit(true)
                 .isFavourite(false)
                 .isSubscribed(false)
-                .visibility("PUBLIC")
-                .latitude(50.45)
-                .longitude(30.52)
-                .onlineLink(null)
+                .isOrganizer(true)
                 .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(liveEvent), PageRequest.of(0, 10), 1);
@@ -1168,22 +1130,18 @@ class EventControllerTest {
         EventPreviewDto passedEvent = EventPreviewDto.builder()
                 .id(3L)
                 .title("Passed Event")
-                .description("Already finished")
-                .open(true)
-                .organizerId(5L)
                 .titleImage("passed-image.jpg")
-                .createdAt(OffsetDateTime.now().minusDays(2))
-                .updatedAt(OffsetDateTime.now().minusDays(2))
                 .status(EventStatus.PASSED)
                 .nearestStart(OffsetDateTime.now().minusDays(1))
+                .nearestFinish(OffsetDateTime.now().minusHours(10))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
                 .canCancelJoin(false)
                 .canEdit(false)
                 .isFavourite(false)
                 .isSubscribed(false)
-                .visibility("PUBLIC")
-                .latitude(50.45)
-                .longitude(30.52)
-                .onlineLink(null)
+                .isOrganizer(true)
                 .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(passedEvent), PageRequest.of(0, 10), 1);
@@ -1207,22 +1165,18 @@ class EventControllerTest {
         EventPreviewDto upcomingEvent = EventPreviewDto.builder()
                 .id(4L)
                 .title("Related Upcoming Event")
-                .description("Test Description")
-                .open(true)
-                .organizerId(5L)
                 .titleImage("test-image.jpg")
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
                 .status(EventStatus.UPCOMING)
                 .nearestStart(OffsetDateTime.now().plusDays(2))
+                .nearestFinish(OffsetDateTime.now().plusDays(2).plusHours(3))
+                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+                .distance(null)
+                .visibility("open")
                 .canCancelJoin(true)
                 .canEdit(true)
                 .isFavourite(false)
                 .isSubscribed(false)
-                .visibility("PUBLIC")
-                .latitude(50.45)
-                .longitude(30.52)
-                .onlineLink(null)
+                .isOrganizer(true)
                 .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(upcomingEvent), PageRequest.of(0, 10), 1);

--- a/core/src/test/java/greencity/controller/EventControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventControllerTest.java
@@ -64,25 +64,25 @@ class EventControllerTest {
     MockMvc mockMvc;
 
     ObjectMapper objectMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        .registerModule(new JavaTimeModule())
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     private static final String EVENT_NOT_FOUND_MESSAGE_PREFIX = "Event doesn't exist by this id: ";
     private static final String USER_NO_PERMISSION_MESSAGE = "Current user has no permission for this action";
 
     // Mock the authenticated user
     UserVO mockUser = UserVO.builder()
-            .id(5L)
-            .email("test@example.com")
-            .name("Test User")
-            .build();
+        .id(5L)
+        .email("test@example.com")
+        .name("Test User")
+        .build();
 
     static class ForcedMessageErrorAttributes extends DefaultErrorAttributes {
         @Override
         public Map<String, Object> getErrorAttributes(WebRequest webRequest, ErrorAttributeOptions options) {
             ErrorAttributeOptions newOptions = options.including(
-                    ErrorAttributeOptions.Include.MESSAGE,
-                    ErrorAttributeOptions.Include.EXCEPTION);
+                ErrorAttributeOptions.Include.MESSAGE,
+                ErrorAttributeOptions.Include.EXCEPTION);
             return super.getErrorAttributes(webRequest, newOptions);
         }
     }
@@ -98,31 +98,31 @@ class EventControllerTest {
         @Override
         public boolean supportsParameter(MethodParameter parameter) {
             return parameter.getParameterAnnotation(CurrentUser.class) != null
-                    && parameter.getParameterType().equals(UserVO.class);
+                && parameter.getParameterType().equals(UserVO.class);
         }
 
         @Override
         public Object resolveArgument(MethodParameter parameter,
-                                      ModelAndViewContainer mavContainer,
-                                      NativeWebRequest webRequest,
-                                      WebDataBinderFactory binderFactory) throws Exception {
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
             return userVO;
         }
     }
 
     EventDateLocationDto locationDto = EventDateLocationDto.builder()
-            .startDate(OffsetDateTime.now().plusDays(2))
-            .finishDate(OffsetDateTime.now().plusDays(2).plusHours(3))
-            .latitude(50.45)
-            .longitude(30.52)
-            .build();
+        .startDate(OffsetDateTime.now().plusDays(2))
+        .finishDate(OffsetDateTime.now().plusDays(2).plusHours(3))
+        .latitude(50.45)
+        .longitude(30.52)
+        .build();
 
     AddEventDtoRequest addEventDtoRequest = AddEventDtoRequest.builder()
-            .title("Eco Cleanup")
-            .description("Let's clean the park together for a better future!")
-            .open(true)
-            .datesLocations(List.of(locationDto))
-            .build();
+        .title("Eco Cleanup")
+        .description("Let's clean the park together for a better future!")
+        .open(true)
+        .datesLocations(List.of(locationDto))
+        .build();
 
     @BeforeEach
     void setup() {
@@ -130,10 +130,10 @@ class EventControllerTest {
 
         CustomExceptionHandler exceptionHandler = new CustomExceptionHandler(errorAttributes, objectMapper);
         mockMvc = MockMvcBuilders.standaloneSetup(eventController)
-                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
-                        new TestUserArgumentResolver(mockUser))
-                .setControllerAdvice(exceptionHandler)
-                .build();
+            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(),
+                new TestUserArgumentResolver(mockUser))
+            .setControllerAdvice(exceptionHandler)
+            .build();
     }
 
     private byte[] createValidJpegBytes() {
@@ -166,110 +166,110 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile image = new MockMultipartFile(
-                "images",
-                "test.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                createValidJpegBytes());
+            "images",
+            "test.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            createValidJpegBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-                .id(1L)
-                .title("Eco Cleanup")
-                .description("Let's clean the park together for a better future!")
-                .open(true)
-                .organizerId(5L)
-                .titleImage("event-1-uuid.jpg")
-                .imageUrls(List.of("event-1-uuid.jpg"))
-                .datesLocations(List.of(locationDto))
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .id(1L)
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .organizerId(5L)
+            .titleImage("event-1-uuid.jpg")
+            .imageUrls(List.of("event-1-uuid.jpg"))
+            .datesLocations(List.of(locationDto))
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-                .thenReturn(responseDto);
+            .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.title").value("Eco Cleanup"))
-                .andExpect(jsonPath("$.organizerId").value(5))
-                .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.jpg"));
+            .file(dtoPart)
+            .file(image)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.title").value("Eco Cleanup"))
+            .andExpect(jsonPath("$.organizerId").value(5))
+            .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.jpg"));
     }
 
     @Test
     void createEvent_ShouldReturn400BadRequest() throws Exception {
         AddEventDtoRequest invalidDto = AddEventDtoRequest.builder()
-                .title("")
-                .description("Too short")
-                .open(true)
-                .datesLocations(List.of(locationDto))
-                .build();
+            .title("")
+            .description("Too short")
+            .open(true)
+            .datesLocations(List.of(locationDto))
+            .build();
 
         String json = objectMapper.writeValueAsString(invalidDto);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         MockMultipartFile image = new MockMultipartFile(
-                "images",
-                "test.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                createValidJpegBytes());
+            "images",
+            "test.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            createValidJpegBytes());
 
         when(eventService.createEvent(any(), any(), anyLong()))
-                .thenThrow(new BadRequestException("Title must be between 1 and 70 characters"));
+            .thenThrow(new BadRequestException("Title must be between 1 and 70 characters"));
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .file(dtoPart)
+            .file(image)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     void getVisibleEvents_ShouldReturn200() throws Exception {
         EventDto openEvent = EventDto.builder()
-                .id(1L)
-                .title("Public Cleanup")
-                .description("Open event for everyone")
-                .open(true)
-                .organizerId(3L)
-                .build();
+            .id(1L)
+            .title("Public Cleanup")
+            .description("Open event for everyone")
+            .open(true)
+            .organizerId(3L)
+            .build();
 
         EventDto friendEvent = EventDto.builder()
-                .id(2L)
-                .title("Recycling Workshop")
-                .description("Learn how to recycle effectively at home.")
-                .open(false)
-                .organizerId(2L)
-                .build();
+            .id(2L)
+            .title("Recycling Workshop")
+            .description("Learn how to recycle effectively at home.")
+            .open(false)
+            .organizerId(2L)
+            .build();
 
         List<EventDto> visibleEvents = List.of(openEvent, friendEvent);
 
         when(eventService.getVisibleEvents(any(UserVO.class))).thenReturn(visibleEvents);
 
         mockMvc.perform(get("/events/visible")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$", hasSize(2)))
-                .andExpect(jsonPath("$[0].title").value("Public Cleanup"))
-                .andExpect(jsonPath("$[0].open").value(true))
-                .andExpect(jsonPath("$[1].title").value("Recycling Workshop"))
-                .andExpect(jsonPath("$[1].open").value(false));
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", hasSize(2)))
+            .andExpect(jsonPath("$[0].title").value("Public Cleanup"))
+            .andExpect(jsonPath("$[0].open").value(true))
+            .andExpect(jsonPath("$[1].title").value("Recycling Workshop"))
+            .andExpect(jsonPath("$[1].open").value(false));
     }
 
     @Test
@@ -278,23 +278,23 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile image = new MockMultipartFile(
-                "images",
-                "test.gif",
-                MediaType.IMAGE_GIF_VALUE,
-                "fake-image-content".getBytes());
+            "images",
+            "test.gif",
+            MediaType.IMAGE_GIF_VALUE,
+            "fake-image-content".getBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .file(dtoPart)
+            .file(image)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -303,39 +303,39 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile image = new MockMultipartFile(
-                "images",
-                "test.png",
-                MediaType.IMAGE_PNG_VALUE,
-                createValidPngBytes());
+            "images",
+            "test.png",
+            MediaType.IMAGE_PNG_VALUE,
+            createValidPngBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-                .id(1L)
-                .title("Eco Cleanup")
-                .description("Let's clean the park together for a better future!")
-                .open(true)
-                .organizerId(5L)
-                .titleImage("event-1-uuid.png")
-                .imageUrls(List.of("event-1-uuid.png"))
-                .datesLocations(List.of(locationDto))
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .id(1L)
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .organizerId(5L)
+            .titleImage("event-1-uuid.png")
+            .imageUrls(List.of("event-1-uuid.png"))
+            .datesLocations(List.of(locationDto))
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-                .thenReturn(responseDto);
+            .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.png"));
+            .file(dtoPart)
+            .file(image)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.imageUrls[0]").value("event-1-uuid.png"));
     }
 
     @Test
@@ -346,23 +346,23 @@ class EventControllerTest {
         // Create a file larger than 10MB
         byte[] largeContent = createValidJpegBytes(11 * 1024 * 1024); // 11MB
         MockMultipartFile oversizedImage = new MockMultipartFile(
-                "images",
-                "large.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                largeContent);
+            "images",
+            "large.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            largeContent);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(oversizedImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .file(dtoPart)
+            .file(oversizedImage)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -373,38 +373,38 @@ class EventControllerTest {
         // Create a file exactly 10MB
         byte[] exactContent = createValidJpegBytes(10 * 1024 * 1024); // Exactly 10MB
         MockMultipartFile exactSizeImage = new MockMultipartFile(
-                "images",
-                "exact.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                exactContent);
+            "images",
+            "exact.jpg",
+            MediaType.IMAGE_JPEG_VALUE,
+            exactContent);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-                .id(1L)
-                .title("Eco Cleanup")
-                .description("Let's clean the park together for a better future!")
-                .open(true)
-                .organizerId(5L)
-                .titleImage("event-1-uuid.jpg")
-                .imageUrls(List.of("event-1-uuid.jpg"))
-                .datesLocations(List.of(locationDto))
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .id(1L)
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .organizerId(5L)
+            .titleImage("event-1-uuid.jpg")
+            .imageUrls(List.of("event-1-uuid.jpg"))
+            .datesLocations(List.of(locationDto))
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-                .thenReturn(responseDto);
+            .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(exactSizeImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated());
+            .file(dtoPart)
+            .file(exactSizeImage)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated());
     }
 
     @Test
@@ -413,36 +413,36 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         // Create 6 images
         MockMultipartFile image1 =
-                new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image2 =
-                new MockMultipartFile("images", "test2.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test2.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image3 =
-                new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image4 =
-                new MockMultipartFile("images", "test4.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test4.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image5 =
-                new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image6 =
-                new MockMultipartFile("images", "test6.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test6.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image1)
-                        .file(image2)
-                        .file(image3)
-                        .file(image4)
-                        .file(image5)
-                        .file(image6)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .file(dtoPart)
+            .file(image1)
+            .file(image2)
+            .file(image3)
+            .file(image4)
+            .file(image5)
+            .file(image6)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -451,51 +451,51 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         // Create exactly 5 images (3 JPEG, 2 PNG)
         MockMultipartFile image1 =
-                new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test1.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image2 =
-                new MockMultipartFile("images", "test2.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
+            new MockMultipartFile("images", "test2.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
         MockMultipartFile image3 =
-                new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test3.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image4 =
-                new MockMultipartFile("images", "test4.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
+            new MockMultipartFile("images", "test4.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
         MockMultipartFile image5 =
-                new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "test5.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
 
         EventDto responseDto = EventDto.builder()
-                .id(1L)
-                .title("Eco Cleanup")
-                .description("Let's clean the park together for a better future!")
-                .open(true)
-                .organizerId(5L)
-                .titleImage("event-1-uuid1.jpg")
-                .imageUrls(List.of("event-1-uuid1.jpg", "event-1-uuid2.png", "event-1-uuid3.jpg", "event-1-uuid4.png",
-                        "event-1-uuid5.jpg"))
-                .datesLocations(List.of(locationDto))
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .id(1L)
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .organizerId(5L)
+            .titleImage("event-1-uuid1.jpg")
+            .imageUrls(List.of("event-1-uuid1.jpg", "event-1-uuid2.png", "event-1-uuid3.jpg", "event-1-uuid4.png",
+                "event-1-uuid5.jpg"))
+            .datesLocations(List.of(locationDto))
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-                .thenReturn(responseDto);
+            .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image1)
-                        .file(image2)
-                        .file(image3)
-                        .file(image4)
-                        .file(image5)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.imageUrls.length()").value(5))
-                .andExpect(jsonPath("$.titleImage").value("event-1-uuid1.jpg"));
+            .file(dtoPart)
+            .file(image1)
+            .file(image2)
+            .file(image3)
+            .file(image4)
+            .file(image5)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.imageUrls.length()").value(5))
+            .andExpect(jsonPath("$.titleImage").value("event-1-uuid1.jpg"));
     }
 
     @Test
@@ -504,33 +504,33 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         EventDto responseDto = EventDto.builder()
-                .id(1L)
-                .title("Eco Cleanup")
-                .description("Let's clean the park together for a better future!")
-                .open(true)
-                .organizerId(5L)
-                .titleImage("default-event-image.jpg")
-                .imageUrls(List.of("default-event-image.jpg"))
-                .datesLocations(List.of(locationDto))
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .id(1L)
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .organizerId(5L)
+            .titleImage("default-event-image.jpg")
+            .imageUrls(List.of("default-event-image.jpg"))
+            .datesLocations(List.of(locationDto))
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(), eq(5L)))
-                .thenReturn(responseDto);
+            .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.titleImage").value("default-event-image.jpg"))
-                .andExpect(jsonPath("$.imageUrls[0]").value("default-event-image.jpg"));
+            .file(dtoPart)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.titleImage").value("default-event-image.jpg"))
+            .andExpect(jsonPath("$.imageUrls[0]").value("default-event-image.jpg"));
     }
 
     @Test
@@ -539,44 +539,44 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         MockMultipartFile image1 =
-                new MockMultipartFile("images", "first.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "first.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile image2 =
-                new MockMultipartFile("images", "second.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
+            new MockMultipartFile("images", "second.png", MediaType.IMAGE_PNG_VALUE, createValidPngBytes());
         MockMultipartFile image3 =
-                new MockMultipartFile("images", "third.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "third.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
 
         EventDto responseDto = EventDto.builder()
-                .id(1L)
-                .title("Eco Cleanup")
-                .description("Let's clean the park together for a better future!")
-                .open(true)
-                .organizerId(5L)
-                .titleImage("event-1-first.jpg") // First image becomes main
-                .imageUrls(List.of("event-1-first.jpg", "event-1-second.png", "event-1-third.jpg"))
-                .datesLocations(List.of(locationDto))
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .id(1L)
+            .title("Eco Cleanup")
+            .description("Let's clean the park together for a better future!")
+            .open(true)
+            .organizerId(5L)
+            .titleImage("event-1-first.jpg") // First image becomes main
+            .imageUrls(List.of("event-1-first.jpg", "event-1-second.png", "event-1-third.jpg"))
+            .datesLocations(List.of(locationDto))
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         when(eventService.createEvent(any(AddEventDtoRequest.class), any(MultipartFile[].class), eq(5L)))
-                .thenReturn(responseDto);
+            .thenReturn(responseDto);
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(image1)
-                        .file(image2)
-                        .file(image3)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.titleImage").value("event-1-first.jpg"))
-                .andExpect(jsonPath("$.imageUrls[0]").value("event-1-first.jpg"))
-                .andExpect(jsonPath("$.imageUrls.length()").value(3));
+            .file(dtoPart)
+            .file(image1)
+            .file(image2)
+            .file(image3)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.titleImage").value("event-1-first.jpg"))
+            .andExpect(jsonPath("$.imageUrls[0]").value("event-1-first.jpg"))
+            .andExpect(jsonPath("$.imageUrls.length()").value(3));
     }
 
     @Test
@@ -585,23 +585,23 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile imageWithoutContentType = new MockMultipartFile(
-                "images",
-                "test.jpg",
-                null, // No content type
-                "fake-content".getBytes());
+            "images",
+            "test.jpg",
+            null, // No content type
+            "fake-content".getBytes());
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(imageWithoutContentType)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .file(dtoPart)
+            .file(imageWithoutContentType)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -610,44 +610,44 @@ class EventControllerTest {
         String json = objectMapper.writeValueAsString(addEventDtoRequest);
 
         MockMultipartFile dtoPart = new MockMultipartFile(
-                "addEventDtoRequest",
-                "",
-                MediaType.APPLICATION_JSON_VALUE,
-                json.getBytes());
+            "addEventDtoRequest",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            json.getBytes());
 
         MockMultipartFile validImage =
-                new MockMultipartFile("images", "valid.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
+            new MockMultipartFile("images", "valid.jpg", MediaType.IMAGE_JPEG_VALUE, createValidJpegBytes());
         MockMultipartFile invalidImage =
-                new MockMultipartFile("images", "invalid.bmp", "image/bmp", "invalid-content".getBytes());
+            new MockMultipartFile("images", "invalid.bmp", "image/bmp", "invalid-content".getBytes());
 
         mockMvc.perform(multipart("/events/create")
-                        .file(dtoPart)
-                        .file(validImage)
-                        .file(invalidImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+            .file(dtoPart)
+            .file(validImage)
+            .file(invalidImage)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     void getMyEvents_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-                .id(1L)
-                .title("Test Event")
-                .titleImage("test-image.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(false)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(false)
-                .build();
+            .id(1L)
+            .title("Test Event")
+            .titleImage("test-image.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(false)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(false)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -655,35 +655,35 @@ class EventControllerTest {
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents")
-                        .param("eventType", "BOTH")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content[0].id").value(1))
-                .andExpect(jsonPath("$.content[0].title").value("Test Event"))
-                .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
-                .andExpect(jsonPath("$.totalElements").value(1));
+            .param("eventType", "BOTH")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].title").value("Test Event"))
+            .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
+            .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getMyEventsWithCoordinates_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-                .id(1L)
-                .title("Test Event")
-                .titleImage("test-image.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(1.23)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(false)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(false)
-                .build();
+            .id(1L)
+            .title("Test Event")
+            .titleImage("test-image.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(1.23)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(false)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(false)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -691,37 +691,37 @@ class EventControllerTest {
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents")
-                        .param("eventType", "PLACE")
-                        .param("userLatitude", "50.45")
-                        .param("userLongitude", "30.52")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content[0].id").value(1))
-                .andExpect(jsonPath("$.content[0].title").value("Test Event"))
-                .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
-                .andExpect(jsonPath("$.totalElements").value(1));
+            .param("eventType", "PLACE")
+            .param("userLatitude", "50.45")
+            .param("userLongitude", "30.52")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].title").value("Test Event"))
+            .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
+            .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getMyEventsWithOnlineTypeNoCoordinates_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-                .id(1L)
-                .title("Online Event")
-                .titleImage("online-event.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(3))
-                .types(greencity.dto.event.EventTypesDto.builder().place(false).online(true).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(false)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(false)
-                .build();
+            .id(1L)
+            .title("Online Event")
+            .titleImage("online-event.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(3))
+            .types(greencity.dto.event.EventTypesDto.builder().place(false).online(true).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(false)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(false)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -729,34 +729,34 @@ class EventControllerTest {
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents")
-                        .param("eventType", "ONLINE")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content[0].id").value(1))
-                .andExpect(jsonPath("$.content[0].title").value("Online Event"))
-                .andExpect(jsonPath("$.totalElements").value(1));
+            .param("eventType", "ONLINE")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].title").value("Online Event"))
+            .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getMyCreatedEvents_ShouldReturn200Ok() throws Exception {
 
         EventPreviewDto eventPreview = EventPreviewDto.builder()
-                .id(1L)
-                .title("My Created Event")
-                .titleImage("my-event-image.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(true)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(1L)
+            .title("My Created Event")
+            .titleImage("my-event-image.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(true)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(eventPreview), PageRequest.of(0, 10), 1);
 
@@ -764,15 +764,15 @@ class EventControllerTest {
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/createdEvents")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content[0].id").value(1))
-                .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
-                // unified DTO no longer exposes organizerId
-                .andExpect(jsonPath("$.content[0].canEdit").value(true))
-                .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
-                .andExpect(jsonPath("$.totalElements").value(1));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
+            // unified DTO no longer exposes organizerId
+            .andExpect(jsonPath("$.content[0].canEdit").value(true))
+            .andExpect(jsonPath("$.content[0].status").value("UPCOMING"))
+            .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
@@ -782,7 +782,7 @@ class EventControllerTest {
         doNothing().when(eventService).deleteEvent(eventId, mockUser);
 
         mockMvc.perform(delete("/events/delete/{eventId}", eventId))
-                .andExpect(status().isOk());
+            .andExpect(status().isOk());
 
         verify(eventService).deleteEvent(eventId, mockUser);
     }
@@ -793,12 +793,12 @@ class EventControllerTest {
         String errorMessage = USER_NO_PERMISSION_MESSAGE;
 
         doThrow(new UnauthorizedException(errorMessage))
-                .when(eventService).deleteEvent(eventId, mockUser);
+            .when(eventService).deleteEvent(eventId, mockUser);
 
         mockMvc.perform(delete("/events/delete/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value(errorMessage));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -807,12 +807,12 @@ class EventControllerTest {
         String errorMessage = EVENT_NOT_FOUND_MESSAGE_PREFIX + eventId;
 
         doThrow(new NotFoundException(errorMessage))
-                .when(eventService).deleteEvent(eventId, mockUser);
+            .when(eventService).deleteEvent(eventId, mockUser);
 
         mockMvc.perform(delete("/events/delete/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value(errorMessage));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -822,9 +822,9 @@ class EventControllerTest {
         when(eventService.removeAttender(eventId, mockUser)).thenReturn(true);
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.removed").value(true));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.removed").value(true));
 
         verify(eventService).removeAttender(eventId, mockUser);
     }
@@ -836,9 +836,9 @@ class EventControllerTest {
         when(eventService.removeAttender(eventId, mockUser)).thenReturn(false);
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.removed").value(false));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.removed").value(false));
 
         verify(eventService).removeAttender(eventId, mockUser);
     }
@@ -849,12 +849,12 @@ class EventControllerTest {
         String errorMessage = EVENT_NOT_FOUND_MESSAGE_PREFIX + eventId;
 
         when(eventService.removeAttender(eventId, mockUser))
-                .thenThrow(new NotFoundException(errorMessage));
+            .thenThrow(new NotFoundException(errorMessage));
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value(errorMessage));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -863,12 +863,12 @@ class EventControllerTest {
         String errorMessage = "Cannot cancel attendance for events that have already passed";
 
         when(eventService.removeAttender(eventId, mockUser))
-                .thenThrow(new BadRequestException(errorMessage));
+            .thenThrow(new BadRequestException(errorMessage));
 
         mockMvc.perform(delete("/events/removeAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value(errorMessage));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
@@ -878,9 +878,9 @@ class EventControllerTest {
         when(eventService.addAttender(eventId, mockUser)).thenReturn(true);
 
         mockMvc.perform(post("/events/addAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.added").value(true));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.added").value(true));
 
         verify(eventService).addAttender(eventId, mockUser);
     }
@@ -892,9 +892,9 @@ class EventControllerTest {
         when(eventService.addAttender(eventId, mockUser)).thenReturn(false);
 
         mockMvc.perform(post("/events/addAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.added").value(false));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.added").value(false));
 
         verify(eventService).addAttender(eventId, mockUser);
     }
@@ -905,33 +905,33 @@ class EventControllerTest {
         String errorMessage = EVENT_NOT_FOUND_MESSAGE_PREFIX + eventId;
 
         when(eventService.addAttender(eventId, mockUser))
-                .thenThrow(new NotFoundException(errorMessage));
+            .thenThrow(new NotFoundException(errorMessage));
 
         mockMvc.perform(post("/events/addAttender/{eventId}", eventId)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value(errorMessage));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value(errorMessage));
     }
 
     @Test
     void getMyCreatedEvents_ShouldReturnPassedEvents() throws Exception {
 
         EventPreviewDto passedEvent = EventPreviewDto.builder()
-                .id(2L)
-                .title("Past Event")
-                .titleImage("past-event-image.jpg")
-                .status(EventStatus.PASSED)
-                .nearestStart(OffsetDateTime.now().minusDays(5))
-                .nearestFinish(OffsetDateTime.now().minusDays(4))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(false)
-                .canEdit(true)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(2L)
+            .title("Past Event")
+            .titleImage("past-event-image.jpg")
+            .status(EventStatus.PASSED)
+            .nearestStart(OffsetDateTime.now().minusDays(5))
+            .nearestFinish(OffsetDateTime.now().minusDays(4))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(false)
+            .canEdit(true)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(passedEvent), PageRequest.of(0, 10), 1);
 
@@ -939,144 +939,144 @@ class EventControllerTest {
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/createdEvents")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content[0].id").value(2))
-                .andExpect(jsonPath("$.content[0].title").value("Past Event"))
-                .andExpect(jsonPath("$.content[0].status").value("PASSED"))
-                .andExpect(jsonPath("$.content[0].canEdit").value(true))
-                .andExpect(jsonPath("$.totalElements").value(1));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content[0].id").value(2))
+            .andExpect(jsonPath("$.content[0].title").value("Past Event"))
+            .andExpect(jsonPath("$.content[0].status").value("PASSED"))
+            .andExpect(jsonPath("$.content[0].canEdit").value(true))
+            .andExpect(jsonPath("$.totalElements").value(1));
     }
 
     @Test
     void getRelatedEvents_ShouldReturn200Ok() throws Exception {
         // Create test events - mix of created and joined events
         EventPreviewDto createdEvent = EventPreviewDto.builder()
-                .id(1L)
-                .title("My Created Event")
-                .titleImage("created-event.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(true)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(1L)
+            .title("My Created Event")
+            .titleImage("created-event.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(true)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         EventPreviewDto joinedEvent = EventPreviewDto.builder()
-                .id(2L)
-                .title("Joined Event")
-                .titleImage("joined-event.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(2))
-                .nearestFinish(OffsetDateTime.now().plusDays(2).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(false)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(false)
-                .build();
+            .id(2L)
+            .title("Joined Event")
+            .titleImage("joined-event.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(2))
+            .nearestFinish(OffsetDateTime.now().plusDays(2).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(false)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(false)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(
-                List.of(createdEvent, joinedEvent), PageRequest.of(0, 10), 2);
+            List.of(createdEvent, joinedEvent), PageRequest.of(0, 10), 2);
 
         when(eventService.getRelatedEvents(eq(5L), eq(null), any(Pageable.class)))
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/relatedEvents")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content", hasSize(2)))
-                .andExpect(jsonPath("$.content[0].id").value(1))
-                .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
-                .andExpect(jsonPath("$.content[0].canEdit").value(true))
-                .andExpect(jsonPath("$.content[1].id").value(2))
-                .andExpect(jsonPath("$.content[1].title").value("Joined Event"))
-                .andExpect(jsonPath("$.content[1].canEdit").value(false))
-                .andExpect(jsonPath("$.totalElements").value(2));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content", hasSize(2)))
+            .andExpect(jsonPath("$.content[0].id").value(1))
+            .andExpect(jsonPath("$.content[0].title").value("My Created Event"))
+            .andExpect(jsonPath("$.content[0].canEdit").value(true))
+            .andExpect(jsonPath("$.content[1].id").value(2))
+            .andExpect(jsonPath("$.content[1].title").value("Joined Event"))
+            .andExpect(jsonPath("$.content[1].canEdit").value(false))
+            .andExpect(jsonPath("$.totalElements").value(2));
     }
 
     @Test
     void getRelatedEvents_WithPagination_ShouldReturn200Ok() throws Exception {
         EventPreviewDto event = EventPreviewDto.builder()
-                .id(1L)
-                .title("Related Event")
-                .titleImage("event.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(true)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(1L)
+            .title("Related Event")
+            .titleImage("event.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(true)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(
-                List.of(event), PageRequest.of(0, 5), 1);
+            List.of(event), PageRequest.of(0, 5), 1);
 
         when(eventService.getRelatedEvents(eq(5L), eq(null), any(Pageable.class)))
             .thenReturn(eventPage);
 
         mockMvc.perform(get("/events/myEvents/relatedEvents")
-                        .param("page", "0")
-                        .param("size", "5")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content", hasSize(1)))
-                .andExpect(jsonPath("$.totalElements").value(1))
-                .andExpect(jsonPath("$.size").value(5))
-                .andExpect(jsonPath("$.number").value(0));
+            .param("page", "0")
+            .param("size", "5")
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content", hasSize(1)))
+            .andExpect(jsonPath("$.totalElements").value(1))
+            .andExpect(jsonPath("$.size").value(5))
+            .andExpect(jsonPath("$.number").value(0));
     }
 
     @Test
     void getRelatedEvents_EmptyResult_ShouldReturn200Ok() throws Exception {
         Page<EventPreviewDto> emptyPage = new PageImpl<>(
-                List.of(), PageRequest.of(0, 10), 0);
+            List.of(), PageRequest.of(0, 10), 0);
 
         when(eventService.getRelatedEvents(eq(5L), eq(null), any(Pageable.class)))
             .thenReturn(emptyPage);
 
         mockMvc.perform(get("/events/myEvents/relatedEvents")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content", hasSize(0)))
-                .andExpect(jsonPath("$.totalElements").value(0));
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.content", hasSize(0)))
+            .andExpect(jsonPath("$.totalElements").value(0));
     }
 
     @Test
     void getMyEventsWithStatusFilter_ShouldReturnFilteredEvents() throws Exception {
         EventPreviewDto upcomingEvent = EventPreviewDto.builder()
-                .id(1L)
-                .title("Upcoming Event")
-                .titleImage("test-image.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(1))
-                .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(false)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(false)
-                .build();
+            .id(1L)
+            .title("Upcoming Event")
+            .titleImage("test-image.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(1))
+            .nearestFinish(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(false)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(false)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(upcomingEvent), PageRequest.of(0, 10), 1);
 
@@ -1096,21 +1096,21 @@ class EventControllerTest {
     @Test
     void getMyCreatedEventsWithStatusFilter_ShouldReturnFilteredEvents() throws Exception {
         EventPreviewDto liveEvent = EventPreviewDto.builder()
-                .id(2L)
-                .title("Live Event")
-                .titleImage("live-image.jpg")
-                .status(EventStatus.LIVE)
-                .nearestStart(OffsetDateTime.now().minusHours(1))
-                .nearestFinish(OffsetDateTime.now().plusHours(1))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(false)
-                .canEdit(true)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(2L)
+            .title("Live Event")
+            .titleImage("live-image.jpg")
+            .status(EventStatus.LIVE)
+            .nearestStart(OffsetDateTime.now().minusHours(1))
+            .nearestFinish(OffsetDateTime.now().plusHours(1))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(false)
+            .canEdit(true)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(liveEvent), PageRequest.of(0, 10), 1);
 
@@ -1129,21 +1129,21 @@ class EventControllerTest {
     @Test
     void getMyCreatedEventsWithPassedStatus_ShouldHaveCanEditFalse() throws Exception {
         EventPreviewDto passedEvent = EventPreviewDto.builder()
-                .id(3L)
-                .title("Passed Event")
-                .titleImage("passed-image.jpg")
-                .status(EventStatus.PASSED)
-                .nearestStart(OffsetDateTime.now().minusDays(1))
-                .nearestFinish(OffsetDateTime.now().minusHours(10))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(false)
-                .canEdit(false)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(3L)
+            .title("Passed Event")
+            .titleImage("passed-image.jpg")
+            .status(EventStatus.PASSED)
+            .nearestStart(OffsetDateTime.now().minusDays(1))
+            .nearestFinish(OffsetDateTime.now().minusHours(10))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(false)
+            .canEdit(false)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(passedEvent), PageRequest.of(0, 10), 1);
 
@@ -1164,21 +1164,21 @@ class EventControllerTest {
     @Test
     void getRelatedEventsWithStatusFilter_ShouldReturnFilteredEvents() throws Exception {
         EventPreviewDto upcomingEvent = EventPreviewDto.builder()
-                .id(4L)
-                .title("Related Upcoming Event")
-                .titleImage("test-image.jpg")
-                .status(EventStatus.UPCOMING)
-                .nearestStart(OffsetDateTime.now().plusDays(2))
-                .nearestFinish(OffsetDateTime.now().plusDays(2).plusHours(3))
-                .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
-                .distance(null)
-                .visibility("open")
-                .canCancelJoin(true)
-                .canEdit(true)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(true)
-                .build();
+            .id(4L)
+            .title("Related Upcoming Event")
+            .titleImage("test-image.jpg")
+            .status(EventStatus.UPCOMING)
+            .nearestStart(OffsetDateTime.now().plusDays(2))
+            .nearestFinish(OffsetDateTime.now().plusDays(2).plusHours(3))
+            .types(greencity.dto.event.EventTypesDto.builder().place(true).online(false).build())
+            .distance(null)
+            .visibility("open")
+            .canCancelJoin(true)
+            .canEdit(true)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(true)
+            .build();
 
         Page<EventPreviewDto> eventPage = new PageImpl<>(List.of(upcomingEvent), PageRequest.of(0, 10), 1);
 
@@ -1196,7 +1196,7 @@ class EventControllerTest {
     }
 
     @Test
-    public void updateEvent_ShouldReturn200Ok() throws Exception {
+    void updateEvent_ShouldReturn200Ok() throws Exception {
         UpdateEventDtoRequest updateDto = UpdateEventDtoRequest.builder()
             .title("Updated Event")
             .description("This is a new description with more than 20 chars")
@@ -1247,7 +1247,7 @@ class EventControllerTest {
     }
 
     @Test
-    public void updateEvent_WithoutImages_ShouldReturn200Ok() throws Exception {
+    void updateEvent_WithoutImages_ShouldReturn200Ok() throws Exception {
         UpdateEventDtoRequest updateDto = UpdateEventDtoRequest.builder()
             .title("Updated Event No Images")
             .description("Valid description without images")
@@ -1289,7 +1289,7 @@ class EventControllerTest {
     }
 
     @Test
-    public void updateEvent_WithInvalidTitle_ShouldReturn400BadRequest() throws Exception {
+    void updateEvent_WithInvalidTitle_ShouldReturn400BadRequest() throws Exception {
         UpdateEventDtoRequest updateDto = UpdateEventDtoRequest.builder()
             .title("")
             .description("This description is valid")
@@ -1319,7 +1319,7 @@ class EventControllerTest {
     }
 
     @Test
-    public void updateEvent_WithMoreThan5Images_ShouldReturn400BadRequest() throws Exception {
+    void updateEvent_WithMoreThan5Images_ShouldReturn400BadRequest() throws Exception {
         UpdateEventDtoRequest updateDto = UpdateEventDtoRequest.builder()
             .title("Too many images")
             .description("Valid description")

--- a/core/src/test/java/greencity/repository/EventAttenderRepoTest.java
+++ b/core/src/test/java/greencity/repository/EventAttenderRepoTest.java
@@ -20,17 +20,17 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Integration tests for EventAttenderRepo.
- * Tests custom queries, attendance management, and event filtering.
+ * Integration tests for EventAttenderRepo. Tests custom queries, attendance
+ * management, and event filtering.
  *
  * @author Generated
  */
 @DataJpaTest
 @ContextConfiguration(classes = greencity.DaoApplication.class)
 @TestPropertySource(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop",
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.liquibase.enabled=false"
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.datasource.url=jdbc:h2:mem:testdb",
+    "spring.liquibase.enabled=false"
 })
 class EventAttenderRepoTest {
     @Autowired
@@ -88,8 +88,7 @@ class EventAttenderRepoTest {
         // When
         Pageable pageable = PageRequest.of(0, 10);
         Page<Event> result = eventAttenderRepo.findJoinedEventsDefaultSorting(
-                999L, OffsetDateTime.now(), pageable
-        );
+            999L, OffsetDateTime.now(), pageable);
 
         // Then
         assertEquals(0, result.getTotalElements());
@@ -99,10 +98,10 @@ class EventAttenderRepoTest {
     void saveAndFind_EventAttenderPersistence() {
         // Given
         EventAttender attender = EventAttender.builder()
-                .eventId(placeEvent.getId())
-                .userId(userId1)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .eventId(placeEvent.getId())
+            .userId(userId1)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         // When
         EventAttender saved = eventAttenderRepo.save(attender);
@@ -117,24 +116,24 @@ class EventAttenderRepoTest {
     // Helper methods to create different event types
     private Event createPlaceEvent(Long id) {
         Event event = Event.builder()
-                .id(id)
-                .title("Place Event")
-                .description("This is a test event description with enough characters.")
-                .open(true)
-                .organizerId(1L)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Place Event")
+            .description("This is a test event description with enough characters.")
+            .open(true)
+            .organizerId(1L)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation location = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .latitude(50.4501)
-                .longitude(30.5234)
-                .onlineLink(null)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .latitude(50.4501)
+            .longitude(30.5234)
+            .onlineLink(null)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         event.setDateTimeLocations(new ArrayList<>(List.of(location)));
         return event;
@@ -142,24 +141,24 @@ class EventAttenderRepoTest {
 
     private Event createOnlineEvent(Long id) {
         Event event = Event.builder()
-                .id(id)
-                .title("Online Event")
-                .description("This is a test event description with enough characters.")
-                .open(true)
-                .organizerId(1L)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Online Event")
+            .description("This is a test event description with enough characters.")
+            .open(true)
+            .organizerId(1L)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation location = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .latitude(null)
-                .longitude(null)
-                .onlineLink("https://example.com/meeting")
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .latitude(null)
+            .longitude(null)
+            .onlineLink("https://example.com/meeting")
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         event.setDateTimeLocations(new ArrayList<>(List.of(location)));
         return event;
@@ -167,39 +166,36 @@ class EventAttenderRepoTest {
 
     private Event createHybridEvent(Long id) {
         Event event = Event.builder()
-                .id(id)
-                .title("Hybrid Event")
-                .description("This is a test event description with enough characters.")
-                .open(true)
-                .organizerId(1L)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Hybrid Event")
+            .description("This is a test event description with enough characters.")
+            .open(true)
+            .organizerId(1L)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation location1 = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .latitude(50.4501)
-                .longitude(30.5234)
-                .onlineLink(null)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .latitude(50.4501)
+            .longitude(30.5234)
+            .onlineLink(null)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation location2 = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(2))
-                .finishDate(OffsetDateTime.now().plusDays(2).plusHours(2))
-                .latitude(null)
-                .longitude(null)
-                .onlineLink("https://example.com/meeting")
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(2))
+            .finishDate(OffsetDateTime.now().plusDays(2).plusHours(2))
+            .latitude(null)
+            .longitude(null)
+            .onlineLink("https://example.com/meeting")
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         event.setDateTimeLocations(new ArrayList<>(List.of(location1, location2)));
         return event;
     }
 }
-
-
-

--- a/core/src/test/java/greencity/repository/EventAttenderRepoTest.java
+++ b/core/src/test/java/greencity/repository/EventAttenderRepoTest.java
@@ -1,0 +1,205 @@
+package greencity.repository;
+
+import greencity.entity.Event;
+import greencity.entity.EventAttender;
+import greencity.entity.EventDateTimeLocation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for EventAttenderRepo.
+ * Tests custom queries, attendance management, and event filtering.
+ *
+ * @author Generated
+ */
+@DataJpaTest
+@ContextConfiguration(classes = greencity.DaoApplication.class)
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.liquibase.enabled=false"
+})
+class EventAttenderRepoTest {
+    @Autowired
+    private EventAttenderRepo eventAttenderRepo;
+
+    @Autowired
+    private EventRepo eventRepo;
+
+    @Autowired
+    private EventDateTimeLocationRepo dateTimeLocationRepo;
+
+    private Event placeEvent;
+    private Event onlineEvent;
+    private Event hybridEvent;
+    private Long userId1;
+    private Long userId2;
+
+    @BeforeEach
+    void setUp() {
+        userId1 = 100L;
+        userId2 = 200L;
+
+        eventAttenderRepo.deleteAll();
+        dateTimeLocationRepo.deleteAll();
+        eventRepo.deleteAll();
+
+        // Create events
+        placeEvent = createPlaceEvent(1L);
+        onlineEvent = createOnlineEvent(2L);
+        hybridEvent = createHybridEvent(3L);
+
+        eventRepo.saveAll(List.of(placeEvent, onlineEvent, hybridEvent));
+    }
+
+    @Test
+    void existsByEventIdAndUserId_WhenAttenderNotExists_ReturnsFalse() {
+        // When
+        boolean exists = eventAttenderRepo.existsByEventIdAndUserId(placeEvent.getId(), userId1);
+
+        // Then
+        assertFalse(exists);
+    }
+
+    @Test
+    void deleteByEventIdAndUserId_WithNonExistentAttender_ReturnsZero() {
+        // When
+        int deletedCount = eventAttenderRepo.deleteByEventIdAndUserId(999L, 999L);
+
+        // Then
+        assertEquals(0, deletedCount);
+    }
+
+    @Test
+    void findJoinedEventsDefaultSorting_WithNoJoinedEvents_ReturnsEmpty() {
+        // When
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Event> result = eventAttenderRepo.findJoinedEventsDefaultSorting(
+                999L, OffsetDateTime.now(), pageable
+        );
+
+        // Then
+        assertEquals(0, result.getTotalElements());
+    }
+
+    @Test
+    void saveAndFind_EventAttenderPersistence() {
+        // Given
+        EventAttender attender = EventAttender.builder()
+                .eventId(placeEvent.getId())
+                .userId(userId1)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        // When
+        EventAttender saved = eventAttenderRepo.save(attender);
+
+        // Then
+        assertNotNull(saved);
+        assertEquals(placeEvent.getId(), saved.getEventId());
+        assertEquals(userId1, saved.getUserId());
+        assertNotNull(saved.getCreatedAt());
+    }
+
+    // Helper methods to create different event types
+    private Event createPlaceEvent(Long id) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Place Event")
+                .description("This is a test event description with enough characters.")
+                .open(true)
+                .organizerId(1L)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation location = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .latitude(50.4501)
+                .longitude(30.5234)
+                .onlineLink(null)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        event.setDateTimeLocations(new ArrayList<>(List.of(location)));
+        return event;
+    }
+
+    private Event createOnlineEvent(Long id) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Online Event")
+                .description("This is a test event description with enough characters.")
+                .open(true)
+                .organizerId(1L)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation location = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .latitude(null)
+                .longitude(null)
+                .onlineLink("https://example.com/meeting")
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        event.setDateTimeLocations(new ArrayList<>(List.of(location)));
+        return event;
+    }
+
+    private Event createHybridEvent(Long id) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Hybrid Event")
+                .description("This is a test event description with enough characters.")
+                .open(true)
+                .organizerId(1L)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation location1 = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .latitude(50.4501)
+                .longitude(30.5234)
+                .onlineLink(null)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation location2 = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(2))
+                .finishDate(OffsetDateTime.now().plusDays(2).plusHours(2))
+                .latitude(null)
+                .longitude(null)
+                .onlineLink("https://example.com/meeting")
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        event.setDateTimeLocations(new ArrayList<>(List.of(location1, location2)));
+        return event;
+    }
+}
+
+
+

--- a/core/src/test/java/greencity/repository/EventRepoTest.java
+++ b/core/src/test/java/greencity/repository/EventRepoTest.java
@@ -22,17 +22,17 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Integration tests for EventRepo.
- * Tests database queries, pagination, and sorting.
+ * Integration tests for EventRepo. Tests database queries, pagination, and
+ * sorting.
  *
  * @author Generated
  */
 @DataJpaTest
 @ContextConfiguration(classes = greencity.DaoApplication.class)
 @TestPropertySource(properties = {
-        "spring.jpa.hibernate.ddl-auto=create-drop",
-        "spring.datasource.url=jdbc:h2:mem:testdb",
-        "spring.liquibase.enabled=false"
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.datasource.url=jdbc:h2:mem:testdb",
+    "spring.liquibase.enabled=false"
 })
 class EventRepoTest {
     @Autowired
@@ -134,43 +134,43 @@ class EventRepoTest {
     // Helper methods
     private Event createEvent(Long id, Long organizerId, String title) {
         Event event = Event.builder()
-                .id(id)
-                .title(title)
-                .description("This is a test event description with enough characters to be valid.")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title(title)
+            .description("This is a test event description with enough characters to be valid.")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         // Add date locations
         EventDateTimeLocation loc1 = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .latitude(50.4501)
-                .longitude(30.5234)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .latitude(50.4501)
+            .longitude(30.5234)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation loc2 = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(5))
-                .finishDate(OffsetDateTime.now().plusDays(5).plusHours(3))
-                .latitude(50.4501)
-                .longitude(30.5234)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(5))
+            .finishDate(OffsetDateTime.now().plusDays(5).plusHours(3))
+            .latitude(50.4501)
+            .longitude(30.5234)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         event.setDateTimeLocations(new ArrayList<>(List.of(loc1, loc2)));
 
         // Add image
         EventImage image = EventImage.builder()
-                .event(event)
-                .imagePath("event-" + id + ".jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("event-" + id + ".jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(new ArrayList<>(List.of(image)));
 
         return event;
@@ -178,32 +178,32 @@ class EventRepoTest {
 
     private Event createEventWithSpecificStart(Long id, Long organizerId, String title, OffsetDateTime startDate) {
         Event event = Event.builder()
-                .id(id)
-                .title(title)
-                .description("This is a test event description with enough characters to be valid.")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title(title)
+            .description("This is a test event description with enough characters to be valid.")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation location = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(startDate)
-                .finishDate(startDate.plusHours(2))
-                .latitude(50.4501)
-                .longitude(30.5234)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .startDate(startDate)
+            .finishDate(startDate.plusHours(2))
+            .latitude(50.4501)
+            .longitude(30.5234)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         event.setDateTimeLocations(new ArrayList<>(List.of(location)));
 
         EventImage image = EventImage.builder()
-                .event(event)
-                .imagePath("event-" + id + ".jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("event-" + id + ".jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(new ArrayList<>(List.of(image)));
 
         return event;

--- a/core/src/test/java/greencity/repository/EventRepoTest.java
+++ b/core/src/test/java/greencity/repository/EventRepoTest.java
@@ -1,0 +1,211 @@
+package greencity.repository;
+
+import greencity.entity.Event;
+import greencity.entity.EventAttender;
+import greencity.entity.EventDateTimeLocation;
+import greencity.entity.EventImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for EventRepo.
+ * Tests database queries, pagination, and sorting.
+ *
+ * @author Generated
+ */
+@DataJpaTest
+@ContextConfiguration(classes = greencity.DaoApplication.class)
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.liquibase.enabled=false"
+})
+class EventRepoTest {
+    @Autowired
+    private EventRepo eventRepo;
+
+    @Autowired
+    private EventDateTimeLocationRepo dateTimeLocationRepo;
+
+    @Autowired
+    private EventImageRepo eventImageRepo;
+
+    private Long organizerId1;
+    private Long organizerId2;
+
+    @BeforeEach
+    void setUp() {
+        organizerId1 = 100L;
+        organizerId2 = 200L;
+        eventRepo.deleteAll();
+        dateTimeLocationRepo.deleteAll();
+        eventImageRepo.deleteAll();
+    }
+
+    @Test
+    void saveEvent_WithLocationsAndImages_SavesCorrectly() {
+        // Given
+        Event event = createEvent(1L, organizerId1, "Test Event 1");
+
+        // When
+        Event savedEvent = eventRepo.save(event);
+
+        // Then
+        assertNotNull(savedEvent.getId());
+        assertEquals("Test Event 1", savedEvent.getTitle());
+        assertEquals(organizerId1, savedEvent.getOrganizerId());
+
+        // Verify relationships are persisted
+        Optional<Event> found = eventRepo.findById(savedEvent.getId());
+        assertTrue(found.isPresent());
+        assertEquals(2, found.get().getDateTimeLocations().size());
+        assertEquals(1, found.get().getImages().size());
+    }
+
+    @Test
+    void findById_WithExistingEvent_ReturnsEvent() {
+        // Given
+        Event event = createEvent(1L, organizerId1, "Test Event");
+        Event saved = eventRepo.save(event);
+
+        // When
+        Optional<Event> found = eventRepo.findById(saved.getId());
+
+        // Then
+        assertTrue(found.isPresent());
+        assertEquals("Test Event", found.get().getTitle());
+        assertEquals(organizerId1, found.get().getOrganizerId());
+    }
+
+    @Test
+    void findById_WithNonExistentEvent_ReturnsEmpty() {
+        // When
+        Optional<Event> found = eventRepo.findById(999L);
+
+        // Then
+        assertFalse(found.isPresent());
+    }
+
+    @Test
+    void findAll_ReturnsAllEvents() {
+        // Given
+        Event event1 = createEvent(1L, organizerId1, "Event 1");
+        Event event2 = createEvent(2L, organizerId2, "Event 2");
+        Event event3 = createEvent(3L, organizerId1, "Event 3");
+
+        eventRepo.saveAll(List.of(event1, event2, event3));
+
+        // When
+        List<Event> allEvents = eventRepo.findAll();
+
+        // Then
+        assertEquals(3, allEvents.size());
+    }
+
+    @Test
+    void deleteById_DeletesEvent() {
+        // Given
+        Event event = createEvent(1L, organizerId1, "Event to Delete");
+        Event saved = eventRepo.save(event);
+        Long eventId = saved.getId();
+
+        // When
+        eventRepo.deleteById(eventId);
+
+        // Then
+        Optional<Event> found = eventRepo.findById(eventId);
+        assertFalse(found.isPresent());
+    }
+
+    // Helper methods
+    private Event createEvent(Long id, Long organizerId, String title) {
+        Event event = Event.builder()
+                .id(id)
+                .title(title)
+                .description("This is a test event description with enough characters to be valid.")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        // Add date locations
+        EventDateTimeLocation loc1 = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .latitude(50.4501)
+                .longitude(30.5234)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation loc2 = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(5))
+                .finishDate(OffsetDateTime.now().plusDays(5).plusHours(3))
+                .latitude(50.4501)
+                .longitude(30.5234)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        event.setDateTimeLocations(new ArrayList<>(List.of(loc1, loc2)));
+
+        // Add image
+        EventImage image = EventImage.builder()
+                .event(event)
+                .imagePath("event-" + id + ".jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(new ArrayList<>(List.of(image)));
+
+        return event;
+    }
+
+    private Event createEventWithSpecificStart(Long id, Long organizerId, String title, OffsetDateTime startDate) {
+        Event event = Event.builder()
+                .id(id)
+                .title(title)
+                .description("This is a test event description with enough characters to be valid.")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation location = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(startDate)
+                .finishDate(startDate.plusHours(2))
+                .latitude(50.4501)
+                .longitude(30.5234)
+                .createdAt(OffsetDateTime.now())
+                .build();
+
+        event.setDateTimeLocations(new ArrayList<>(List.of(location)));
+
+        EventImage image = EventImage.builder()
+                .event(event)
+                .imagePath("event-" + id + ".jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(new ArrayList<>(List.of(image)));
+
+        return event;
+    }
+}

--- a/service-api/src/main/java/greencity/dto/event/EventPreviewDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventPreviewDto.java
@@ -13,20 +13,16 @@ import java.time.OffsetDateTime;
 public class EventPreviewDto {
     private Long id;
     private String title;
-    private String description;
-    private boolean open;
-    private Long organizerId;
     private String titleImage;
-    private OffsetDateTime createdAt;
-    private OffsetDateTime updatedAt;
     private EventStatus status;
     private OffsetDateTime nearestStart;
+    private OffsetDateTime nearestFinish;
+    private EventTypesDto types;
+    private Double distance;
+    private String visibility; // "open" | "closed"
     private boolean canCancelJoin;
     private boolean canEdit;
     private boolean isFavourite;
     private boolean isSubscribed;
-    private String visibility;
-    private Double latitude;
-    private Double longitude;
-    private String onlineLink;
+    private boolean isOrganizer;
 }

--- a/service-api/src/main/java/greencity/dto/event/EventTypesDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventTypesDto.java
@@ -1,0 +1,14 @@
+package greencity.dto.event;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+@EqualsAndHashCode
+public class EventTypesDto {
+    private boolean place;
+    private boolean online;
+}

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -49,28 +49,28 @@ public class EventServiceImpl implements EventService {
     public EventDto createEvent(AddEventDtoRequest dto, MultipartFile[] images, Long organizerId) {
         validateEvent(dto, images);
         Event event = Event.builder()
-            .title(dto.getTitle().trim())
-            .description(dto.getDescription().trim())
-            .open(dto.isOpen())
-            .organizerId(organizerId)
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .title(dto.getTitle().trim())
+                .description(dto.getDescription().trim())
+                .open(dto.isOpen())
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         event = eventRepository.save(event);
 
         Event finalEvent = event;
         List<EventDateTimeLocation> dateLocations = dto.getDatesLocations().stream()
-            .map(d -> EventDateTimeLocation.builder()
-                .event(finalEvent)
-                .startDate(d.getStartDate())
-                .finishDate(d.getFinishDate())
-                .latitude(d.getLatitude())
-                .longitude(d.getLongitude())
-                .onlineLink(d.getOnlineLink())
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(null)
-                .build())
-            .collect(Collectors.toList());
+                .map(d -> EventDateTimeLocation.builder()
+                        .event(finalEvent)
+                        .startDate(d.getStartDate())
+                        .finishDate(d.getFinishDate())
+                        .latitude(d.getLatitude())
+                        .longitude(d.getLongitude())
+                        .onlineLink(d.getOnlineLink())
+                        .createdAt(OffsetDateTime.now())
+                        .updatedAt(null)
+                        .build())
+                .collect(Collectors.toList());
 
         dateTimeLocationRepository.saveAll(dateLocations);
         event.setDateTimeLocations(dateLocations);
@@ -80,11 +80,11 @@ public class EventServiceImpl implements EventService {
 
         for (int i = 0; i < imagePaths.size(); i++) {
             EventImage img = EventImage.builder()
-                .event(event)
-                .imagePath(imagePaths.get(i))
-                .main(i == 0) // перше зображення — головне
-                .createdAt(OffsetDateTime.now())
-                .build();
+                    .event(event)
+                    .imagePath(imagePaths.get(i))
+                    .main(i == 0) // перше зображення — головне
+                    .createdAt(OffsetDateTime.now())
+                    .build();
             eventImages.add(img);
         }
 
@@ -113,14 +113,18 @@ public class EventServiceImpl implements EventService {
             Double longitude = (userLongitude != null) ? userLongitude : 0.0;
 
             events = eventAttenderRepo.findJoinedEventsWithSorting(
-                userId, currentTime, eventType.name(), latitude, longitude, pageable);
+                    userId, currentTime, eventType.name(), latitude, longitude, pageable);
         } else {
             events = eventAttenderRepo.findJoinedEventsDefaultSorting(
-                userId, currentTime, pageable);
+                    userId, currentTime, pageable);
         }
 
+        // Resolve current user role for flag computation
+        UserVO currentUser = userService.findById(userId);
+        boolean isAdmin = currentUser.getRole() == Role.ROLE_ADMIN;
+
         List<EventPreviewDto> eventPreviews = events.getContent().stream()
-                .map(this::toEventPreviewDto)
+                .map(event -> toEventPreviewDtoWithContext(event, userId, isAdmin, userLatitude, userLongitude, eventType))
                 .filter(event -> status == null || event.getStatus() == status)
                 .collect(Collectors.toList());
 
@@ -162,108 +166,105 @@ public class EventServiceImpl implements EventService {
     }
 
     private EventPreviewDto toEventPreviewDto(Event event) {
-        // Find the nearest start date
-        OffsetDateTime nearestStart = event.getDateTimeLocations().stream()
-            .map(EventDateTimeLocation::getStartDate)
-            .min(OffsetDateTime::compareTo)
-            .orElse(null);
-
-        // Find the corresponding finish date for the nearest start date
-        OffsetDateTime nearestFinish = event.getDateTimeLocations().stream()
-            .filter(loc -> loc.getStartDate().equals(nearestStart))
-            .findFirst()
-            .map(EventDateTimeLocation::getFinishDate)
-            .orElse(null);
-
-        // Determine event status using actual finish date
-        EventStatus status = determineEventStatus(nearestStart, nearestFinish);
-
-        // Get the first date location for coordinates and online link
-        EventDateTimeLocation firstLocation = event.getDateTimeLocations().stream()
-            .findFirst()
-            .orElse(null);
-
-        // Get main image
-        String titleImage = event.getImages().stream()
-            .filter(EventImage::isMain)
-            .findFirst()
-            .map(EventImage::getImagePath)
-            .orElse(null);
-
-        return EventPreviewDto.builder()
-            .id(event.getId())
-            .title(event.getTitle())
-            .description(event.getDescription())
-            .open(event.isOpen())
-            .organizerId(event.getOrganizerId())
-            .titleImage(titleImage)
-            .createdAt(event.getCreatedAt())
-            .updatedAt(event.getUpdatedAt())
-            .status(status)
-            .nearestStart(nearestStart)
-            .canCancelJoin(status != EventStatus.LIVE && status != EventStatus.PASSED)
-            .isFavourite(false) // TODO: Implement when favorites feature is added
-            .isSubscribed(false) // TODO: Implement when subscription feature is added
-            .visibility(event.isOpen() ? "PUBLIC" : "PRIVATE")
-            .latitude(firstLocation != null ? firstLocation.getLatitude() : null)
-            .longitude(firstLocation != null ? firstLocation.getLongitude() : null)
-            .onlineLink(firstLocation != null ? firstLocation.getOnlineLink() : null)
-            .build();
+        return toEventPreviewDtoWithContext(event, null, false, null, null, null);
     }
 
     private EventPreviewDto toEventPreviewDtoWithCanEdit(Event event, Long currentUserId, boolean isAdmin) {
-        // Find the nearest start date
-        OffsetDateTime nearestStart = event.getDateTimeLocations().stream()
-            .map(EventDateTimeLocation::getStartDate)
-            .min(OffsetDateTime::compareTo)
-            .orElse(null);
+        return toEventPreviewDtoWithContext(event, currentUserId, isAdmin, null, null, null);
+    }
 
-        // Find the corresponding finish date for the nearest start date
-        OffsetDateTime nearestFinish = event.getDateTimeLocations().stream()
-            .filter(loc -> loc.getStartDate().equals(nearestStart))
-            .findFirst()
-            .map(EventDateTimeLocation::getFinishDate)
-            .orElse(null);
+    private EventPreviewDto toEventPreviewDtoWithContext(
+            Event event,
+            Long currentUserId,
+            boolean isAdmin,
+            Double userLatitude,
+            Double userLongitude,
+            EventType eventType) {
 
-        // Determine event status using actual finish date
-        EventStatus status = determineEventStatus(nearestStart, nearestFinish);
+        // Compute status and nearest times using shared calculator
+        EventStatusCalculator.EventStatusResult statusResult =
+                EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
 
-        // Get the first date location for coordinates and online link
-        EventDateTimeLocation firstLocation = event.getDateTimeLocations().stream()
-            .findFirst()
-            .orElse(null);
+        // Determine flags and ownership
+        boolean isOrganizer = currentUserId != null && event.getOrganizerId() != null
+                && event.getOrganizerId().equals(currentUserId);
+        boolean canEdit = (isOrganizer || isAdmin) && statusResult.getStatus() != EventStatus.PASSED;
+        boolean canCancelJoin = statusResult.getStatus() != EventStatus.LIVE
+                && statusResult.getStatus() != EventStatus.PASSED;
 
-        // Get main image
+        // Determine event types
+        boolean hasPlace = event.getDateTimeLocations().stream()
+                .anyMatch(loc -> loc.getLatitude() != null && loc.getLongitude() != null);
+        boolean hasOnline = event.getDateTimeLocations().stream()
+                .anyMatch(loc -> loc.getOnlineLink() != null && !loc.getOnlineLink().isBlank());
+
+        EventTypesDto types = EventTypesDto.builder()
+                .place(hasPlace)
+                .online(hasOnline)
+                .build();
+
+        // Compute distance only when user coords provided (nullable)
+        Double distance = computeMinDistanceKm(event, userLatitude, userLongitude,
+                eventType != null ? eventType : EventType.BOTH);
+
+        // Title image
         String titleImage = event.getImages().stream()
-            .filter(EventImage::isMain)
-            .findFirst()
-            .map(EventImage::getImagePath)
-            .orElse(null);
-
-        // Determine canEdit: true if user is organizer or admin, but false for PASSED events
-        boolean canEdit = (event.getOrganizerId().equals(currentUserId) || isAdmin)
-                && status != EventStatus.PASSED;
+                .filter(EventImage::isMain)
+                .findFirst()
+                .map(EventImage::getImagePath)
+                .orElse(null);
 
         return EventPreviewDto.builder()
-            .id(event.getId())
-            .title(event.getTitle())
-            .description(event.getDescription())
-            .open(event.isOpen())
-            .organizerId(event.getOrganizerId())
-            .titleImage(titleImage)
-            .createdAt(event.getCreatedAt())
-            .updatedAt(event.getUpdatedAt())
-            .status(status)
-            .nearestStart(nearestStart)
-            .canCancelJoin(status != EventStatus.LIVE && status != EventStatus.PASSED)
-            .canEdit(canEdit)
-            .isFavourite(false) // TODO: Implement when favorites feature is added
-            .isSubscribed(false) // TODO: Implement when subscription feature is added
-            .visibility(event.isOpen() ? "PUBLIC" : "PRIVATE")
-            .latitude(firstLocation != null ? firstLocation.getLatitude() : null)
-            .longitude(firstLocation != null ? firstLocation.getLongitude() : null)
-            .onlineLink(firstLocation != null ? firstLocation.getOnlineLink() : null)
-            .build();
+                .id(event.getId())
+                .title(event.getTitle())
+                .titleImage(titleImage)
+                .status(statusResult.getStatus())
+                .nearestStart(statusResult.getNearestStart())
+                .nearestFinish(statusResult.getNearestFinish())
+                .types(types)
+                .distance(distance)
+                .visibility(event.isOpen() ? "open" : "closed")
+                .canCancelJoin(canCancelJoin)
+                .canEdit(canEdit)
+                .isFavourite(false)
+                .isSubscribed(false)
+                .isOrganizer(isOrganizer)
+                .build();
+    }
+
+    private Double computeMinDistanceKm(Event event, Double userLatitude, Double userLongitude, EventType eventType) {
+        if (userLatitude == null || userLongitude == null) {
+            return null;
+        }
+        if (eventType != EventType.PLACE) {
+            return null;
+        }
+        List<EventDateTimeLocation> locations = event.getDateTimeLocations();
+        if (locations == null || locations.isEmpty()) {
+            return null;
+        }
+        Double min = null;
+        for (EventDateTimeLocation loc : locations) {
+            if (loc.getLatitude() == null || loc.getLongitude() == null) {
+                continue;
+            }
+            double d = haversineKm(userLatitude, userLongitude, loc.getLatitude(), loc.getLongitude());
+            if (min == null || d < min) {
+                min = d;
+            }
+        }
+        return min;
+    }
+
+    private double haversineKm(double lat1, double lon1, double lat2, double lon2) {
+        double R = 6371.0; // km
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
     }
 
     private EventStatus determineEventStatus(OffsetDateTime nearestStart, OffsetDateTime finishDate) {
@@ -292,7 +293,7 @@ public class EventServiceImpl implements EventService {
      */
     public EventDto getEventById(Long eventId) {
         Event event = eventRepository.findById(eventId)
-            .orElseThrow(() -> new NotFoundException("Event with id " + eventId + " not found"));
+                .orElseThrow(() -> new NotFoundException("Event with id " + eventId + " not found"));
 
         return toEventDto(event);
     }
@@ -308,9 +309,9 @@ public class EventServiceImpl implements EventService {
         List<Event> allEvents = eventRepository.findAll();
 
         return allEvents.stream()
-            .filter(event -> event.isOpen() || isFriend(event.getOrganizerId(), userVO))
-            .map(this::toEventDto)
-            .collect(Collectors.toList());
+                .filter(event -> event.isOpen() || isFriend(event.getOrganizerId(), userVO))
+                .map(this::toEventDto)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -332,42 +333,42 @@ public class EventServiceImpl implements EventService {
      */
     private EventDto toEventDto(Event event) {
         List<EventDateLocationDto> dateDtos = event.getDateTimeLocations().stream()
-            .map(loc -> EventDateLocationDto.builder()
-                .startDate(loc.getStartDate())
-                .finishDate(loc.getFinishDate())
-                .latitude(loc.getLatitude())
-                .longitude(loc.getLongitude())
-                .onlineLink(loc.getOnlineLink())
-                .build())
-            .collect(Collectors.toList());
+                .map(loc -> EventDateLocationDto.builder()
+                        .startDate(loc.getStartDate())
+                        .finishDate(loc.getFinishDate())
+                        .latitude(loc.getLatitude())
+                        .longitude(loc.getLongitude())
+                        .onlineLink(loc.getOnlineLink())
+                        .build())
+                .collect(Collectors.toList());
 
         List<String> imageUrls = event.getImages().stream()
-            .map(EventImage::getImagePath)
-            .collect(Collectors.toList());
+                .map(EventImage::getImagePath)
+                .collect(Collectors.toList());
 
         // Compute event status based on date/time occurrences
         EventStatusCalculator.EventStatusResult statusResult =
-            EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
+                EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
 
         return EventDto.builder()
-            .id(event.getId())
-            .title(event.getTitle())
-            .description(event.getDescription())
-            .open(event.isOpen())
-            .organizerId(event.getOrganizerId())
-            .titleImage(event.getImages().stream()
-                .filter(EventImage::isMain)
-                .findFirst()
-                .map(EventImage::getImagePath)
-                .orElse(null))
-            .createdAt(event.getCreatedAt())
-            .updatedAt(event.getUpdatedAt())
-            .datesLocations(dateDtos)
-            .imageUrls(imageUrls)
-            .status(statusResult.getStatus())
-            .nearestStart(statusResult.getNearestStart())
-            .nearestFinish(statusResult.getNearestFinish())
-            .build();
+                .id(event.getId())
+                .title(event.getTitle())
+                .description(event.getDescription())
+                .open(event.isOpen())
+                .organizerId(event.getOrganizerId())
+                .titleImage(event.getImages().stream()
+                        .filter(EventImage::isMain)
+                        .findFirst()
+                        .map(EventImage::getImagePath)
+                        .orElse(null))
+                .createdAt(event.getCreatedAt())
+                .updatedAt(event.getUpdatedAt())
+                .datesLocations(dateDtos)
+                .imageUrls(imageUrls)
+                .status(statusResult.getStatus())
+                .nearestStart(statusResult.getNearestStart())
+                .nearestFinish(statusResult.getNearestFinish())
+                .build();
     }
 
     /**
@@ -381,8 +382,8 @@ public class EventServiceImpl implements EventService {
         }
 
         if (dto.getDescription() == null
-            || dto.getDescription().length() < 20
-            || dto.getDescription().length() > 63206) {
+                || dto.getDescription().length() < 20
+                || dto.getDescription().length() > 63206) {
             throw new BadRequestException("Description must be between 20 and 63,206 characters");
         }
 
@@ -454,8 +455,8 @@ public class EventServiceImpl implements EventService {
         eventRepository.deleteById(id);
 
         List<String> imagesToDelete = eventDto.getImageUrls() != null
-            ? new ArrayList<>(eventDto.getImageUrls())
-            : Collections.emptyList();
+                ? new ArrayList<>(eventDto.getImageUrls())
+                : Collections.emptyList();
 
         imagesToDelete.forEach(imageStorageService::deleteImage);
     }
@@ -468,8 +469,8 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventDto findById(Long id) {
         Event event = eventRepository
-            .findById(id)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + id));
+                .findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + id));
         return toEventDto(event);
     }
 
@@ -481,7 +482,7 @@ public class EventServiceImpl implements EventService {
     public boolean addAttender(Long eventId, UserVO user) {
         // Check if event exists
         eventRepository.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
 
         // Check if user is already an attender
         if (eventAttenderRepo.existsByEventIdAndUserId(eventId, user.getId())) {
@@ -490,10 +491,10 @@ public class EventServiceImpl implements EventService {
 
         // Create new attender record
         EventAttender attender = EventAttender.builder()
-            .eventId(eventId)
-            .userId(user.getId())
-            .createdAt(OffsetDateTime.now())
-            .build();
+                .eventId(eventId)
+                .userId(user.getId())
+                .createdAt(OffsetDateTime.now())
+                .build();
 
         eventAttenderRepo.save(attender);
         return true;
@@ -507,7 +508,7 @@ public class EventServiceImpl implements EventService {
     public boolean removeAttender(Long eventId, UserVO user) {
         // Check if event exists
         Event event = eventRepository.findById(eventId)
-            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
 
         // Check if event status is PASSED - disallow cancellation
         EventDto eventDto = toEventDto(event);

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -50,12 +50,12 @@ public class EventServiceImpl implements EventService {
     public EventDto createEvent(AddEventDtoRequest dto, MultipartFile[] images, Long organizerId) {
         validateEvent(dto, images);
         Event event = Event.builder()
-                .title(dto.getTitle().trim())
-                .description(dto.getDescription().trim())
-                .open(dto.isOpen())
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .title(dto.getTitle().trim())
+            .description(dto.getDescription().trim())
+            .open(dto.isOpen())
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         event = eventRepository.save(event);
 
@@ -81,11 +81,11 @@ public class EventServiceImpl implements EventService {
 
         for (int i = 0; i < imagePaths.size(); i++) {
             EventImage img = EventImage.builder()
-                    .event(event)
-                    .imagePath(imagePaths.get(i))
-                    .main(i == 0) // перше зображення — головне
-                    .createdAt(OffsetDateTime.now())
-                    .build();
+                .event(event)
+                .imagePath(imagePaths.get(i))
+                .main(i == 0) // перше зображення — головне
+                .createdAt(OffsetDateTime.now())
+                .build();
             eventImages.add(img);
         }
 
@@ -119,10 +119,10 @@ public class EventServiceImpl implements EventService {
             Double longitude = (userLongitude != null) ? userLongitude : 0.0;
 
             events = eventAttenderRepo.findJoinedEventsWithSorting(
-                    userId, currentTime, eventType.name(), latitude, longitude, pageable);
+                userId, currentTime, eventType.name(), latitude, longitude, pageable);
         } else {
             events = eventAttenderRepo.findJoinedEventsDefaultSorting(
-                    userId, currentTime, pageable);
+                userId, currentTime, pageable);
         }
 
         // Resolve current user role for flag computation
@@ -130,7 +130,7 @@ public class EventServiceImpl implements EventService {
         boolean isAdmin = currentUser.getRole() == Role.ROLE_ADMIN;
 
         List<EventPreviewDto> eventPreviews = events.getContent().stream()
-            .map(this::toEventPreviewDto)
+            .map(event -> toEventPreviewDtoWithContext(event, userId, isAdmin, userLatitude, userLongitude, eventType))
             .filter(event -> status == null || event.getStatus() == status)
             .toList();
 
@@ -267,62 +267,61 @@ public class EventServiceImpl implements EventService {
     }
 
     private EventPreviewDto toEventPreviewDtoWithContext(
-            Event event,
-            Long currentUserId,
-            boolean isAdmin,
-            Double userLatitude,
-            Double userLongitude,
-            EventType eventType) {
-
+        Event event,
+        Long currentUserId,
+        boolean isAdmin,
+        Double userLatitude,
+        Double userLongitude,
+        EventType eventType) {
         // Compute status and nearest times using shared calculator
         EventStatusCalculator.EventStatusResult statusResult =
-                EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
+            EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
 
         // Determine flags and ownership
         boolean isOrganizer = currentUserId != null && event.getOrganizerId() != null
-                && event.getOrganizerId().equals(currentUserId);
+            && event.getOrganizerId().equals(currentUserId);
         boolean canEdit = (isOrganizer || isAdmin) && statusResult.getStatus() != EventStatus.PASSED;
         boolean canCancelJoin = statusResult.getStatus() != EventStatus.LIVE
-                && statusResult.getStatus() != EventStatus.PASSED;
+            && statusResult.getStatus() != EventStatus.PASSED;
 
         // Determine event types
         boolean hasPlace = event.getDateTimeLocations().stream()
-                .anyMatch(loc -> loc.getLatitude() != null && loc.getLongitude() != null);
+            .anyMatch(loc -> loc.getLatitude() != null && loc.getLongitude() != null);
         boolean hasOnline = event.getDateTimeLocations().stream()
-                .anyMatch(loc -> loc.getOnlineLink() != null && !loc.getOnlineLink().isBlank());
+            .anyMatch(loc -> loc.getOnlineLink() != null && !loc.getOnlineLink().isBlank());
 
         EventTypesDto types = EventTypesDto.builder()
-                .place(hasPlace)
-                .online(hasOnline)
-                .build();
+            .place(hasPlace)
+            .online(hasOnline)
+            .build();
 
         // Compute distance only when user coords provided (nullable)
         Double distance = computeMinDistanceKm(event, userLatitude, userLongitude,
-                eventType != null ? eventType : EventType.BOTH);
+            eventType != null ? eventType : EventType.BOTH);
 
         // Title image
         String titleImage = event.getImages().stream()
-                .filter(EventImage::isMain)
-                .findFirst()
-                .map(EventImage::getImagePath)
-                .orElse(null);
+            .filter(EventImage::isMain)
+            .findFirst()
+            .map(EventImage::getImagePath)
+            .orElse(null);
 
         return EventPreviewDto.builder()
-                .id(event.getId())
-                .title(event.getTitle())
-                .titleImage(titleImage)
-                .status(statusResult.getStatus())
-                .nearestStart(statusResult.getNearestStart())
-                .nearestFinish(statusResult.getNearestFinish())
-                .types(types)
-                .distance(distance)
-                .visibility(event.isOpen() ? "open" : "closed")
-                .canCancelJoin(canCancelJoin)
-                .canEdit(canEdit)
-                .isFavourite(false)
-                .isSubscribed(false)
-                .isOrganizer(isOrganizer)
-                .build();
+            .id(event.getId())
+            .title(event.getTitle())
+            .titleImage(titleImage)
+            .status(statusResult.getStatus())
+            .nearestStart(statusResult.getNearestStart())
+            .nearestFinish(statusResult.getNearestFinish())
+            .types(types)
+            .distance(distance)
+            .visibility(event.isOpen() ? "open" : "closed")
+            .canCancelJoin(canCancelJoin)
+            .canEdit(canEdit)
+            .isFavourite(false)
+            .isSubscribed(false)
+            .isOrganizer(isOrganizer)
+            .build();
     }
 
     private Double computeMinDistanceKm(Event event, Double userLatitude, Double userLongitude, EventType eventType) {
@@ -350,14 +349,14 @@ public class EventServiceImpl implements EventService {
     }
 
     private double haversineKm(double lat1, double lon1, double lat2, double lon2) {
-        double R = 6371.0; // km
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLon = Math.toRadians(lon2 - lon1);
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
-                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double rad = 6371.0; // km
+        double diffLat = Math.toRadians(lat2 - lat1);
+        double diffLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(diffLat / 2) * Math.sin(diffLat / 2)
+            + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(diffLon / 2) * Math.sin(diffLon / 2);
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return R * c;
+        return rad * c;
     }
 
     /**
@@ -391,7 +390,7 @@ public class EventServiceImpl implements EventService {
      */
     public EventDto getEventById(Long eventId) {
         Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new NotFoundException("Event with id " + eventId + " not found"));
+            .orElseThrow(() -> new NotFoundException("Event with id " + eventId + " not found"));
 
         return toEventDto(event);
     }
@@ -446,27 +445,27 @@ public class EventServiceImpl implements EventService {
 
         // Compute event status based on date/time occurrences
         EventStatusCalculator.EventStatusResult statusResult =
-                EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
+            EventStatusCalculator.computeStatus(event.getDateTimeLocations(), OffsetDateTime.now());
 
         return EventDto.builder()
-                .id(event.getId())
-                .title(event.getTitle())
-                .description(event.getDescription())
-                .open(event.isOpen())
-                .organizerId(event.getOrganizerId())
-                .titleImage(event.getImages().stream()
-                        .filter(EventImage::isMain)
-                        .findFirst()
-                        .map(EventImage::getImagePath)
-                        .orElse(null))
-                .createdAt(event.getCreatedAt())
-                .updatedAt(event.getUpdatedAt())
-                .datesLocations(dateDtos)
-                .imageUrls(imageUrls)
-                .status(statusResult.getStatus())
-                .nearestStart(statusResult.getNearestStart())
-                .nearestFinish(statusResult.getNearestFinish())
-                .build();
+            .id(event.getId())
+            .title(event.getTitle())
+            .description(event.getDescription())
+            .open(event.isOpen())
+            .organizerId(event.getOrganizerId())
+            .titleImage(event.getImages().stream()
+                .filter(EventImage::isMain)
+                .findFirst()
+                .map(EventImage::getImagePath)
+                .orElse(null))
+            .createdAt(event.getCreatedAt())
+            .updatedAt(event.getUpdatedAt())
+            .datesLocations(dateDtos)
+            .imageUrls(imageUrls)
+            .status(statusResult.getStatus())
+            .nearestStart(statusResult.getNearestStart())
+            .nearestFinish(statusResult.getNearestFinish())
+            .build();
     }
 
     /**
@@ -480,8 +479,8 @@ public class EventServiceImpl implements EventService {
         }
 
         if (dto.getDescription() == null
-                || dto.getDescription().length() < 20
-                || dto.getDescription().length() > 63206) {
+            || dto.getDescription().length() < 20
+            || dto.getDescription().length() > 63206) {
             throw new BadRequestException("Description must be between 20 and 63,206 characters");
         }
 
@@ -553,8 +552,8 @@ public class EventServiceImpl implements EventService {
         eventRepository.deleteById(id);
 
         List<String> imagesToDelete = eventDto.getImageUrls() != null
-                ? new ArrayList<>(eventDto.getImageUrls())
-                : Collections.emptyList();
+            ? new ArrayList<>(eventDto.getImageUrls())
+            : Collections.emptyList();
 
         imagesToDelete.forEach(imageStorageService::deleteImage);
     }
@@ -567,8 +566,8 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventDto findById(Long id) {
         Event event = eventRepository
-                .findById(id)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + id));
+            .findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + id));
         return toEventDto(event);
     }
 
@@ -582,7 +581,7 @@ public class EventServiceImpl implements EventService {
     public boolean addAttender(Long eventId, UserVO user) {
         // Check if event exists
         eventRepository.findById(eventId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
 
         // Check if user is already an attender
         if (eventAttenderRepo.existsByEventIdAndUserId(eventId, user.getId())) {
@@ -591,10 +590,10 @@ public class EventServiceImpl implements EventService {
 
         // Create new attender record
         EventAttender attender = EventAttender.builder()
-                .eventId(eventId)
-                .userId(user.getId())
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .eventId(eventId)
+            .userId(user.getId())
+            .createdAt(OffsetDateTime.now())
+            .build();
 
         eventAttenderRepo.save(attender);
         return true;
@@ -610,7 +609,7 @@ public class EventServiceImpl implements EventService {
     public boolean removeAttender(Long eventId, UserVO user) {
         // Check if event exists
         Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.EVENT_NOT_FOUND_BY_ID + eventId));
 
         // Check if event status is PASSED - disallow cancellation
         EventDto eventDto = toEventDto(event);

--- a/service/src/test/java/greencity/service/EventCancellationFlowTest.java
+++ b/service/src/test/java/greencity/service/EventCancellationFlowTest.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Integration tests for the event cancel join (removeAttender) flow.
- * Tests successful cancellation, edge cases, and business rule enforcement.
+ * Integration tests for the event cancel join (removeAttender) flow. Tests
+ * successful cancellation, edge cases, and business rule enforcement.
  */
 @ExtendWith(SpringExtension.class)
 class EventCancellationFlowTest {
@@ -53,30 +53,30 @@ class EventCancellationFlowTest {
 
     private Event buildEvent(Long id, Long organizerId, OffsetDateTime start, OffsetDateTime finish) {
         Event event = Event.builder()
-                .id(id)
-                .title("Event " + id)
-                .description("Test")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Event " + id)
+            .description("Test")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation loc = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(start)
-                .finishDate(finish)
-                .latitude(50.0)
-                .longitude(30.0)
-                .build();
+            .event(event)
+            .startDate(start)
+            .finishDate(finish)
+            .latitude(50.0)
+            .longitude(30.0)
+            .build();
         event.setDateTimeLocations(List.of(loc));
 
         EventImage img = EventImage.builder()
-                .event(event)
-                .imagePath("img.jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("img.jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(List.of(img));
         return event;
     }
@@ -89,8 +89,8 @@ class EventCancellationFlowTest {
 
         UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
         Event event = buildEvent(eventId, organizerId,
-                OffsetDateTime.now().plusDays(1),
-                OffsetDateTime.now().plusDays(1).plusHours(2));
+            OffsetDateTime.now().plusDays(1),
+            OffsetDateTime.now().plusDays(1).plusHours(2));
 
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
         when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(true);
@@ -110,8 +110,8 @@ class EventCancellationFlowTest {
 
         UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
         Event event = buildEvent(eventId, organizerId,
-                OffsetDateTime.now().minusHours(1),
-                OffsetDateTime.now().plusHours(1));
+            OffsetDateTime.now().minusHours(1),
+            OffsetDateTime.now().plusHours(1));
 
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
         when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(true);
@@ -131,16 +131,15 @@ class EventCancellationFlowTest {
 
         UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
         Event event = buildEvent(eventId, organizerId,
-                OffsetDateTime.now().minusDays(2),
-                OffsetDateTime.now().minusDays(1));
+            OffsetDateTime.now().minusDays(2),
+            OffsetDateTime.now().minusDays(1));
 
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
         when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(true);
 
         BadRequestException exception = assertThrows(
-                BadRequestException.class,
-                () -> eventService.removeAttender(eventId, attendee)
-        );
+            BadRequestException.class,
+            () -> eventService.removeAttender(eventId, attendee));
 
         assertTrue(exception.getMessage().contains("passed"));
         verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
@@ -154,8 +153,8 @@ class EventCancellationFlowTest {
 
         UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
         Event event = buildEvent(eventId, organizerId,
-                OffsetDateTime.now().plusDays(1),
-                OffsetDateTime.now().plusDays(1).plusHours(2));
+            OffsetDateTime.now().plusDays(1),
+            OffsetDateTime.now().plusDays(1).plusHours(2));
 
         when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
         when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(false);
@@ -176,10 +175,9 @@ class EventCancellationFlowTest {
         when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
 
         assertThrows(greencity.exception.exceptions.NotFoundException.class,
-                () -> eventService.removeAttender(eventId, attendee));
+            () -> eventService.removeAttender(eventId, attendee));
 
         verify(eventAttenderRepo, never()).existsByEventIdAndUserId(anyLong(), anyLong());
         verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
     }
 }
-

--- a/service/src/test/java/greencity/service/EventCancellationFlowTest.java
+++ b/service/src/test/java/greencity/service/EventCancellationFlowTest.java
@@ -1,0 +1,185 @@
+package greencity.service;
+
+import greencity.entity.Event;
+import greencity.entity.EventDateTimeLocation;
+import greencity.entity.EventImage;
+import greencity.enums.Role;
+import greencity.dto.user.UserVO;
+import greencity.exception.exceptions.BadRequestException;
+import greencity.repository.EventAttenderRepo;
+import greencity.repository.EventDateTimeLocationRepo;
+import greencity.repository.EventImageRepo;
+import greencity.repository.EventRepo;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.modelmapper.ModelMapper;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Integration tests for the event cancel join (removeAttender) flow.
+ * Tests successful cancellation, edge cases, and business rule enforcement.
+ */
+@ExtendWith(SpringExtension.class)
+class EventCancellationFlowTest {
+    @Mock
+    private EventRepo eventRepository;
+    @Mock
+    private EventDateTimeLocationRepo dateTimeLocationRepository;
+    @Mock
+    private EventImageRepo eventImageRepository;
+    @Mock
+    private EventAttenderRepo eventAttenderRepo;
+    @Mock
+    private ImageStorageService imageStorageService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private ModelMapper mapper;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    private Event buildEvent(Long id, Long organizerId, OffsetDateTime start, OffsetDateTime finish) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Event " + id)
+                .description("Test")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation loc = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(start)
+                .finishDate(finish)
+                .latitude(50.0)
+                .longitude(30.0)
+                .build();
+        event.setDateTimeLocations(List.of(loc));
+
+        EventImage img = EventImage.builder()
+                .event(event)
+                .imagePath("img.jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(List.of(img));
+        return event;
+    }
+
+    @Test
+    void cancelJoinUpcomingEvent_Success() {
+        Long eventId = 1L;
+        Long attendeeId = 100L;
+        Long organizerId = 999L;
+
+        UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
+        Event event = buildEvent(eventId, organizerId,
+                OffsetDateTime.now().plusDays(1),
+                OffsetDateTime.now().plusDays(1).plusHours(2));
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(true);
+        when(eventAttenderRepo.deleteByEventIdAndUserId(eventId, attendeeId)).thenReturn(1);
+
+        boolean result = eventService.removeAttender(eventId, attendee);
+
+        assertTrue(result);
+        verify(eventAttenderRepo).deleteByEventIdAndUserId(eventId, attendeeId);
+    }
+
+    @Test
+    void cancelJoinLiveEvent_Success() {
+        Long eventId = 2L;
+        Long attendeeId = 200L;
+        Long organizerId = 999L;
+
+        UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
+        Event event = buildEvent(eventId, organizerId,
+                OffsetDateTime.now().minusHours(1),
+                OffsetDateTime.now().plusHours(1));
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(true);
+        when(eventAttenderRepo.deleteByEventIdAndUserId(eventId, attendeeId)).thenReturn(1);
+
+        boolean result = eventService.removeAttender(eventId, attendee);
+
+        assertTrue(result);
+        verify(eventAttenderRepo).deleteByEventIdAndUserId(eventId, attendeeId);
+    }
+
+    @Test
+    void cancelJoinPassedEvent_ThrowsBadRequestException() {
+        Long eventId = 3L;
+        Long attendeeId = 300L;
+        Long organizerId = 999L;
+
+        UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
+        Event event = buildEvent(eventId, organizerId,
+                OffsetDateTime.now().minusDays(2),
+                OffsetDateTime.now().minusDays(1));
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(true);
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> eventService.removeAttender(eventId, attendee)
+        );
+
+        assertTrue(exception.getMessage().contains("passed"));
+        verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void cancelJoinNotAttender_ReturnsFalse() {
+        Long eventId = 4L;
+        Long attendeeId = 400L;
+        Long organizerId = 999L;
+
+        UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
+        Event event = buildEvent(eventId, organizerId,
+                OffsetDateTime.now().plusDays(1),
+                OffsetDateTime.now().plusDays(1).plusHours(2));
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, attendeeId)).thenReturn(false);
+
+        boolean result = eventService.removeAttender(eventId, attendee);
+
+        assertFalse(result);
+        verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void cancelJoinEventNotFound_ThrowsNotFoundException() {
+        Long eventId = 999L;
+        Long attendeeId = 500L;
+
+        UserVO attendee = UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build();
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
+
+        assertThrows(greencity.exception.exceptions.NotFoundException.class,
+                () -> eventService.removeAttender(eventId, attendee));
+
+        verify(eventAttenderRepo, never()).existsByEventIdAndUserId(anyLong(), anyLong());
+        verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
+    }
+}
+

--- a/service/src/test/java/greencity/service/EventPermissionFlagsTest.java
+++ b/service/src/test/java/greencity/service/EventPermissionFlagsTest.java
@@ -1,0 +1,184 @@
+package greencity.service;
+
+import greencity.dto.event.EventPreviewDto;
+import greencity.entity.Event;
+import greencity.entity.EventDateTimeLocation;
+import greencity.entity.EventImage;
+import greencity.enums.EventStatus;
+import greencity.enums.Role;
+import greencity.dto.user.UserVO;
+import greencity.repository.EventAttenderRepo;
+import greencity.repository.EventDateTimeLocationRepo;
+import greencity.repository.EventImageRepo;
+import greencity.repository.EventRepo;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for event permission flags: canEdit, canCancelJoin, isOrganizer.
+ * Tests flag computation based on user role, ownership, and event status.
+ */
+@ExtendWith(SpringExtension.class)
+class EventPermissionFlagsTest {
+    @Mock
+    private EventRepo eventRepository;
+    @Mock
+    private EventDateTimeLocationRepo dateTimeLocationRepository;
+    @Mock
+    private EventImageRepo eventImageRepository;
+    @Mock
+    private EventAttenderRepo eventAttenderRepo;
+    @Mock
+    private ImageStorageService imageStorageService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private ModelMapper mapper;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    private Event buildEvent(Long id, Long organizerId, OffsetDateTime start, OffsetDateTime finish) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Event " + id)
+                .description("Test")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation loc = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(start)
+                .finishDate(finish)
+                .latitude(50.0)
+                .longitude(30.0)
+                .build();
+        event.setDateTimeLocations(List.of(loc));
+
+        EventImage img = EventImage.builder()
+                .event(event)
+                .imagePath("img.jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(List.of(img));
+        return event;
+    }
+
+    @Test
+    void organizerOfUpcomingEvent_HasCanEditTrue_AndIsOrganizerTrue() {
+        Long organizerId = 100L;
+        Event event = buildEvent(1L, organizerId,
+                OffsetDateTime.now().plusDays(1),
+                OffsetDateTime.now().plusDays(1).plusHours(2));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(organizerId)).thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(organizerId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertTrue(dto.isCanEdit(), "Organizer should have canEdit=true for upcoming events");
+        assertTrue(dto.isOrganizer(), "Organizer should have isOrganizer=true");
+        assertTrue(dto.isCanCancelJoin(), "User should be able to cancel join for upcoming events");
+    }
+
+    @Test
+    void organizerOfPassedEvent_HasCanEditFalse() {
+        Long organizerId = 200L;
+        Event event = buildEvent(2L, organizerId,
+                OffsetDateTime.now().minusDays(2),
+                OffsetDateTime.now().minusDays(1));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(organizerId)).thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(organizerId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertFalse(dto.isCanEdit(), "CanEdit should be false for passed events, even for organizer");
+        assertTrue(dto.isOrganizer(), "Organizer flag should still be true");
+        assertFalse(dto.isCanCancelJoin(), "Cannot cancel join for passed events");
+    }
+
+    @Test
+    void admin_HasCanEditTrueForUpcomingEvents() {
+        Long adminId = 300L;
+        Long eventId = 3L;
+        Event event = buildEvent(eventId, adminId,
+                OffsetDateTime.now().plusDays(1),
+                OffsetDateTime.now().plusDays(1).plusHours(2));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(adminId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(adminId)).thenReturn(UserVO.builder().id(adminId).role(Role.ROLE_ADMIN).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(adminId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertTrue(dto.isCanEdit(), "Admin should have canEdit=true for upcoming events");
+        assertEquals(EventStatus.UPCOMING, dto.getStatus());
+    }
+
+    @Test
+    void nonOrganizer_HasCanEditFalse_AndIsOrganizerFalse() {
+        Long attendeeId = 400L;
+        Long organizerId = 999L;
+        Event event = buildEvent(4L, organizerId,
+                OffsetDateTime.now().plusDays(1),
+                OffsetDateTime.now().plusDays(1).plusHours(2));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(attendeeId), any(), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(attendeeId)).thenReturn(UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyEvents(attendeeId, null, null, null, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertFalse(dto.isCanEdit(), "Non-organizer should have canEdit=false");
+        assertFalse(dto.isOrganizer(), "Non-organizer should have isOrganizer=false");
+        assertTrue(dto.isCanCancelJoin(), "Attendee should be able to cancel join for upcoming events");
+    }
+
+    @Test
+    void liveEvent_DisallowsCancelJoin() {
+        Long organizerId = 500L;
+        Event event = buildEvent(5L, organizerId,
+                OffsetDateTime.now().minusHours(1),
+                OffsetDateTime.now().plusHours(1));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(organizerId)).thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(organizerId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertEquals(EventStatus.LIVE, dto.getStatus());
+        assertFalse(dto.isCanCancelJoin(), "Cannot cancel join for live events");
+        assertTrue(dto.isCanEdit(), "Organizer can still edit live events");
+    }
+}
+

--- a/service/src/test/java/greencity/service/EventPermissionFlagsTest.java
+++ b/service/src/test/java/greencity/service/EventPermissionFlagsTest.java
@@ -57,30 +57,30 @@ class EventPermissionFlagsTest {
 
     private Event buildEvent(Long id, Long organizerId, OffsetDateTime start, OffsetDateTime finish) {
         Event event = Event.builder()
-                .id(id)
-                .title("Event " + id)
-                .description("Test")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Event " + id)
+            .description("Test")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation loc = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(start)
-                .finishDate(finish)
-                .latitude(50.0)
-                .longitude(30.0)
-                .build();
+            .event(event)
+            .startDate(start)
+            .finishDate(finish)
+            .latitude(50.0)
+            .longitude(30.0)
+            .build();
         event.setDateTimeLocations(List.of(loc));
 
         EventImage img = EventImage.builder()
-                .event(event)
-                .imagePath("img.jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("img.jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(List.of(img));
         return event;
     }
@@ -89,12 +89,14 @@ class EventPermissionFlagsTest {
     void organizerOfUpcomingEvent_HasCanEditTrue_AndIsOrganizerTrue() {
         Long organizerId = 100L;
         Event event = buildEvent(1L, organizerId,
-                OffsetDateTime.now().plusDays(1),
-                OffsetDateTime.now().plusDays(1).plusHours(2));
+            OffsetDateTime.now().plusDays(1),
+            OffsetDateTime.now().plusDays(1).plusHours(2));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
-        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class))).thenReturn(page);
-        when(userService.findById(organizerId)).thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class)))
+            .thenReturn(page);
+        when(userService.findById(organizerId))
+            .thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
 
         Page<EventPreviewDto> result = eventService.getMyCreatedEvents(organizerId, null, PageRequest.of(0, 10));
 
@@ -108,12 +110,14 @@ class EventPermissionFlagsTest {
     void organizerOfPassedEvent_HasCanEditFalse() {
         Long organizerId = 200L;
         Event event = buildEvent(2L, organizerId,
-                OffsetDateTime.now().minusDays(2),
-                OffsetDateTime.now().minusDays(1));
+            OffsetDateTime.now().minusDays(2),
+            OffsetDateTime.now().minusDays(1));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
-        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class))).thenReturn(page);
-        when(userService.findById(organizerId)).thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class)))
+            .thenReturn(page);
+        when(userService.findById(organizerId))
+            .thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
 
         Page<EventPreviewDto> result = eventService.getMyCreatedEvents(organizerId, null, PageRequest.of(0, 10));
 
@@ -128,8 +132,8 @@ class EventPermissionFlagsTest {
         Long adminId = 300L;
         Long eventId = 3L;
         Event event = buildEvent(eventId, adminId,
-                OffsetDateTime.now().plusDays(1),
-                OffsetDateTime.now().plusDays(1).plusHours(2));
+            OffsetDateTime.now().plusDays(1),
+            OffsetDateTime.now().plusDays(1).plusHours(2));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(adminId), any(Pageable.class))).thenReturn(page);
@@ -147,14 +151,16 @@ class EventPermissionFlagsTest {
         Long attendeeId = 400L;
         Long organizerId = 999L;
         Event event = buildEvent(4L, organizerId,
-                OffsetDateTime.now().plusDays(1),
-                OffsetDateTime.now().plusDays(1).plusHours(2));
+            OffsetDateTime.now().plusDays(1),
+            OffsetDateTime.now().plusDays(1).plusHours(2));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
-        when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(attendeeId), any(), any(Pageable.class))).thenReturn(page);
+        when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(attendeeId), any(), any(Pageable.class)))
+            .thenReturn(page);
         when(userService.findById(attendeeId)).thenReturn(UserVO.builder().id(attendeeId).role(Role.ROLE_USER).build());
 
-        Page<EventPreviewDto> result = eventService.getMyEvents(attendeeId, null, null, null, null, PageRequest.of(0, 10));
+        Page<EventPreviewDto> result =
+            eventService.getMyEvents(attendeeId, null, null, null, null, PageRequest.of(0, 10));
 
         EventPreviewDto dto = result.getContent().get(0);
         assertFalse(dto.isCanEdit(), "Non-organizer should have canEdit=false");
@@ -166,12 +172,14 @@ class EventPermissionFlagsTest {
     void liveEvent_DisallowsCancelJoin() {
         Long organizerId = 500L;
         Event event = buildEvent(5L, organizerId,
-                OffsetDateTime.now().minusHours(1),
-                OffsetDateTime.now().plusHours(1));
+            OffsetDateTime.now().minusHours(1),
+            OffsetDateTime.now().plusHours(1));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
-        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class))).thenReturn(page);
-        when(userService.findById(organizerId)).thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(organizerId), any(Pageable.class)))
+            .thenReturn(page);
+        when(userService.findById(organizerId))
+            .thenReturn(UserVO.builder().id(organizerId).role(Role.ROLE_USER).build());
 
         Page<EventPreviewDto> result = eventService.getMyCreatedEvents(organizerId, null, PageRequest.of(0, 10));
 
@@ -181,4 +189,3 @@ class EventPermissionFlagsTest {
         assertTrue(dto.isCanEdit(), "Organizer can still edit live events");
     }
 }
-

--- a/service/src/test/java/greencity/service/EventPreviewMappingTest.java
+++ b/service/src/test/java/greencity/service/EventPreviewMappingTest.java
@@ -54,24 +54,25 @@ class EventPreviewMappingTest {
 
     private Event buildPlaceEvent(Long id, Long organizerId, OffsetDateTime start, OffsetDateTime finish) {
         Event event = Event.builder()
-                .id(id)
-                .title("Title " + id)
-                .description("Desc")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Title " + id)
+            .description("Desc")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation loc = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(start)
-                .finishDate(finish)
-                .latitude(50.0)
-                .longitude(30.0)
-                .build();
+            .event(event)
+            .startDate(start)
+            .finishDate(finish)
+            .latitude(50.0)
+            .longitude(30.0)
+            .build();
         event.setDateTimeLocations(List.of(loc));
-        EventImage img = EventImage.builder().event(event).imagePath("main.jpg").main(true).createdAt(OffsetDateTime.now()).build();
+        EventImage img =
+            EventImage.builder().event(event).imagePath("main.jpg").main(true).createdAt(OffsetDateTime.now()).build();
         event.setImages(List.of(img));
         return event;
     }
@@ -79,7 +80,8 @@ class EventPreviewMappingTest {
     @Test
     void getMyCreatedEvents_MapsUnifiedPreviewDtoWithFlags() {
         Long userId = 100L;
-        Event ev = buildPlaceEvent(1L, userId, OffsetDateTime.now().plusDays(1), OffsetDateTime.now().plusDays(1).plusHours(2));
+        Event ev = buildPlaceEvent(1L, userId, OffsetDateTime.now().plusDays(1),
+            OffsetDateTime.now().plusDays(1).plusHours(2));
         Page<Event> page = new PageImpl<>(List.of(ev), PageRequest.of(0, 10), 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
@@ -105,14 +107,17 @@ class EventPreviewMappingTest {
     @Test
     void getMyEvents_PlaceWithCoordinates_ComputesDistanceNullable() {
         Long userId = 200L;
-        Event ev = buildPlaceEvent(1L, 999L, OffsetDateTime.now().plusDays(1), OffsetDateTime.now().plusDays(1).plusHours(1));
+        Event ev =
+            buildPlaceEvent(1L, 999L, OffsetDateTime.now().plusDays(1), OffsetDateTime.now().plusDays(1).plusHours(1));
         Page<Event> page = new PageImpl<>(List.of(ev), PageRequest.of(0, 10), 1);
 
-        when(eventAttenderRepo.findJoinedEventsWithSorting(eq(userId), any(), eq(EventType.PLACE.name()), any(), any(), any(Pageable.class)))
-                .thenReturn(page);
+        when(eventAttenderRepo.findJoinedEventsWithSorting(eq(userId), any(), eq(EventType.PLACE.name()), any(), any(),
+            any(Pageable.class)))
+            .thenReturn(page);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
-        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.PLACE, null, 50.1, 30.1, PageRequest.of(0,10));
+        Page<EventPreviewDto> result =
+            eventService.getMyEvents(userId, EventType.PLACE, null, 50.1, 30.1, PageRequest.of(0, 10));
 
         EventPreviewDto dto = result.getContent().get(0);
         assertEquals(EventStatus.UPCOMING, dto.getStatus());
@@ -123,5 +128,3 @@ class EventPreviewMappingTest {
         assertFalse(dto.isOrganizer());
     }
 }
-
-

--- a/service/src/test/java/greencity/service/EventPreviewMappingTest.java
+++ b/service/src/test/java/greencity/service/EventPreviewMappingTest.java
@@ -1,0 +1,127 @@
+package greencity.service;
+
+import greencity.dto.event.EventPreviewDto;
+import greencity.entity.Event;
+import greencity.entity.EventDateTimeLocation;
+import greencity.entity.EventImage;
+import greencity.enums.EventStatus;
+import greencity.enums.EventType;
+import greencity.enums.Role;
+import greencity.dto.user.UserVO;
+import greencity.repository.EventAttenderRepo;
+import greencity.repository.EventDateTimeLocationRepo;
+import greencity.repository.EventImageRepo;
+import greencity.repository.EventRepo;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class EventPreviewMappingTest {
+    @Mock
+    private EventRepo eventRepository;
+    @Mock
+    private EventDateTimeLocationRepo dateTimeLocationRepository;
+    @Mock
+    private EventImageRepo eventImageRepository;
+    @Mock
+    private EventAttenderRepo eventAttenderRepo;
+    @Mock
+    private ImageStorageService imageStorageService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private ModelMapper mapper;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    private Event buildPlaceEvent(Long id, Long organizerId, OffsetDateTime start, OffsetDateTime finish) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Title " + id)
+                .description("Desc")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation loc = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(start)
+                .finishDate(finish)
+                .latitude(50.0)
+                .longitude(30.0)
+                .build();
+        event.setDateTimeLocations(List.of(loc));
+        EventImage img = EventImage.builder().event(event).imagePath("main.jpg").main(true).createdAt(OffsetDateTime.now()).build();
+        event.setImages(List.of(img));
+        return event;
+    }
+
+    @Test
+    void getMyCreatedEvents_MapsUnifiedPreviewDtoWithFlags() {
+        Long userId = 100L;
+        Event ev = buildPlaceEvent(1L, userId, OffsetDateTime.now().plusDays(1), OffsetDateTime.now().plusDays(1).plusHours(2));
+        Page<Event> page = new PageImpl<>(List.of(ev), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        assertEquals(1, result.getTotalElements());
+        EventPreviewDto dto = result.getContent().get(0);
+        assertEquals(ev.getId(), dto.getId());
+        assertEquals(ev.getTitle(), dto.getTitle());
+        assertEquals(EventStatus.UPCOMING, dto.getStatus());
+        assertNotNull(dto.getNearestStart());
+        assertNotNull(dto.getNearestFinish());
+        assertEquals("open", dto.getVisibility());
+        assertTrue(dto.isCanEdit());
+        assertTrue(dto.isOrganizer());
+        assertNotNull(dto.getTypes());
+        assertTrue(dto.getTypes().isPlace());
+        assertFalse(dto.getTypes().isOnline());
+    }
+
+    @Test
+    void getMyEvents_PlaceWithCoordinates_ComputesDistanceNullable() {
+        Long userId = 200L;
+        Event ev = buildPlaceEvent(1L, 999L, OffsetDateTime.now().plusDays(1), OffsetDateTime.now().plusDays(1).plusHours(1));
+        Page<Event> page = new PageImpl<>(List.of(ev), PageRequest.of(0, 10), 1);
+
+        when(eventAttenderRepo.findJoinedEventsWithSorting(eq(userId), any(), eq(EventType.PLACE.name()), any(), any(), any(Pageable.class)))
+                .thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.PLACE, null, 50.1, 30.1, PageRequest.of(0,10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertEquals(EventStatus.UPCOMING, dto.getStatus());
+        assertNotNull(dto.getNearestStart());
+        assertNotNull(dto.getNearestFinish());
+        assertEquals("open", dto.getVisibility());
+        assertNotNull(dto.getDistance());
+        assertFalse(dto.isOrganizer());
+    }
+}
+
+

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -615,7 +615,7 @@ class EventServiceImplTest {
 
         // When & Then
         assertThrows(NotFoundException.class,
-                () -> eventService.findById(eventId));
+            () -> eventService.findById(eventId));
         verify(eventRepository, times(1)).findById(eventId);
     }
 
@@ -691,7 +691,7 @@ class EventServiceImplTest {
 
         // When & Then
         assertThrows(NotFoundException.class,
-                () -> eventService.addAttender(eventId, user));
+            () -> eventService.addAttender(eventId, user));
     }
 
     @Test
@@ -725,8 +725,8 @@ class EventServiceImplTest {
 
         // When & Then
         greencity.exception.exceptions.BadRequestException exception =
-                assertThrows(greencity.exception.exceptions.BadRequestException.class,
-                        () -> eventService.removeAttender(eventId, user));
+            assertThrows(greencity.exception.exceptions.BadRequestException.class,
+                () -> eventService.removeAttender(eventId, user));
 
         assertTrue(exception.getMessage().contains("passed"));
         verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
@@ -760,7 +760,7 @@ class EventServiceImplTest {
 
         // When & Then
         assertThrows(NotFoundException.class,
-                () -> eventService.removeAttender(eventId, user));
+            () -> eventService.removeAttender(eventId, user));
     }
 
     @Test
@@ -771,7 +771,7 @@ class EventServiceImplTest {
         List<Event> events = List.of(createUpcomingEvent());
 
         when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(userId), any(OffsetDateTime.class), eq(pageable)))
-                .thenReturn(new PageImpl<>(events, pageable, 1));
+            .thenReturn(new PageImpl<>(events, pageable, 1));
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
         // When
@@ -791,8 +791,8 @@ class EventServiceImplTest {
         List<Event> events = List.of(createUpcomingEvent());
 
         when(eventAttenderRepo.findJoinedEventsWithSorting(
-                eq(userId), any(OffsetDateTime.class), eq(EventType.PLACE.name()), any(), any(), eq(pageable)))
-                .thenReturn(new PageImpl<>(events, pageable, 1));
+            eq(userId), any(OffsetDateTime.class), eq(EventType.PLACE.name()), any(), any(), eq(pageable)))
+            .thenReturn(new PageImpl<>(events, pageable, 1));
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
         // When
@@ -813,7 +813,7 @@ class EventServiceImplTest {
         Page<Event> eventPage = new PageImpl<>(Arrays.asList(event), pageable, 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), eq(pageable)))
-                .thenReturn(eventPage);
+            .thenReturn(eventPage);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
         // When
@@ -837,7 +837,7 @@ class EventServiceImplTest {
         Page<Event> eventPage = new PageImpl<>(Arrays.asList(event), pageable, 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), eq(pageable)))
-                .thenReturn(eventPage);
+            .thenReturn(eventPage);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
         // When
@@ -845,9 +845,7 @@ class EventServiceImplTest {
 
         // Then
         assertNotNull(result);
-        result.getContent().forEach(dto ->
-                assertEquals(EventStatus.UPCOMING, dto.getStatus())
-        );
+        result.getContent().forEach(dto -> assertEquals(EventStatus.UPCOMING, dto.getStatus()));
     }
 
     @Test
@@ -860,7 +858,7 @@ class EventServiceImplTest {
         Page<Event> eventPage = new PageImpl<>(Arrays.asList(event), pageable, 1);
 
         when(eventRepository.findRelatedEventsByUserId(eq(userId), eq(pageable)))
-                .thenReturn(eventPage);
+            .thenReturn(eventPage);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
         // When

--- a/service/src/test/java/greencity/service/EventServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventServiceImplTest.java
@@ -1,12 +1,13 @@
 package greencity.service;
 
 import greencity.constant.ErrorMessage;
-import greencity.dto.event.EventDto;
+import greencity.dto.event.*;
 import greencity.dto.user.UserVO;
 import greencity.entity.Event;
 import greencity.entity.EventDateTimeLocation;
 import greencity.entity.EventImage;
 import greencity.enums.EventStatus;
+import greencity.enums.EventType;
 import greencity.enums.Role;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UnauthorizedException;
@@ -20,6 +21,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.Clock;
@@ -69,6 +74,7 @@ class EventServiceImplTest {
     private final Long mockEventId = 1L;
     private final Long mockOrganizerId = 10L;
     private final Long mockOtherUserId = 20L;
+    private final Long mockUserId = 30L;
 
     private UserVO createUserVO(Long id, Role role) {
         return UserVO.builder()
@@ -582,5 +588,287 @@ class EventServiceImplTest {
 
         verify(entityManager, never()).flush();
         verify(entityManager, never()).clear();
+    }
+
+    @Test
+    void findById_WithExistingEvent_ReturnsEventDto() {
+        // Given
+        Long eventId = 1L;
+        Event event = createUpcomingEvent();
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+
+        // When
+        EventDto result = eventService.findById(eventId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(eventId, result.getId());
+        assertEquals(event.getTitle(), result.getTitle());
+        verify(eventRepository, times(1)).findById(eventId);
+    }
+
+    @Test
+    void findById_WithNonExistentEvent_ThrowsNotFoundException() {
+        // Given
+        Long eventId = 999L;
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NotFoundException.class,
+                () -> eventService.findById(eventId));
+        verify(eventRepository, times(1)).findById(eventId);
+    }
+
+    @Test
+    void getVisibleEvents_ReturnsOpenEvents() {
+        // Given
+        Event openEvent = createUpcomingEvent();
+        openEvent.setOpen(true);
+
+        Event closedEvent = createUpcomingEvent();
+        closedEvent.setId(2L);
+        closedEvent.setOrganizerId(999L);
+        closedEvent.setOpen(false);
+
+        when(eventRepository.findAll()).thenReturn(Arrays.asList(openEvent, closedEvent));
+
+        UserVO user = createUserVO(mockOrganizerId, Role.ROLE_USER);
+
+        // When
+        List<EventDto> result = eventService.getVisibleEvents(user);
+
+        // Then
+        assertNotNull(result);
+        // At least the open event should be visible
+        assertTrue(result.size() >= 1);
+    }
+
+    @Test
+    void addAttender_WithValidData_ReturnsTrue() {
+        // Given
+        Long eventId = 1L;
+        Event event = createUpcomingEvent();
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, mockUserId)).thenReturn(false);
+        when(eventAttenderRepo.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        // When
+        boolean result = eventService.addAttender(eventId, user);
+
+        // Then
+        assertTrue(result);
+        verify(eventAttenderRepo).existsByEventIdAndUserId(eventId, mockUserId);
+        verify(eventAttenderRepo).save(any());
+    }
+
+    @Test
+    void addAttender_WhenAlreadyAttender_ReturnsFalse() {
+        // Given
+        Long eventId = 1L;
+        Event event = createUpcomingEvent();
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, mockUserId)).thenReturn(true);
+
+        // When
+        boolean result = eventService.addAttender(eventId, user);
+
+        // Then
+        assertFalse(result);
+        verify(eventAttenderRepo, never()).save(any());
+    }
+
+    @Test
+    void addAttender_WithNonExistentEvent_ThrowsNotFoundException() {
+        // Given
+        Long eventId = 999L;
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NotFoundException.class,
+                () -> eventService.addAttender(eventId, user));
+    }
+
+    @Test
+    void removeAttender_WithUpcomingEvent_ReturnsTrue() {
+        // Given
+        Long eventId = 1L;
+        Event event = createUpcomingEvent();
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, mockUserId)).thenReturn(true);
+        when(eventAttenderRepo.deleteByEventIdAndUserId(eventId, mockUserId)).thenReturn(1);
+
+        // When
+        boolean result = eventService.removeAttender(eventId, user);
+
+        // Then
+        assertTrue(result);
+        verify(eventAttenderRepo).deleteByEventIdAndUserId(eventId, mockUserId);
+    }
+
+    @Test
+    void removeAttender_WithPassedEvent_ThrowsBadRequestException() {
+        // Given
+        Long eventId = 1L;
+        Event event = createPassedEvent();
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, mockUserId)).thenReturn(true);
+
+        // When & Then
+        greencity.exception.exceptions.BadRequestException exception =
+                assertThrows(greencity.exception.exceptions.BadRequestException.class,
+                        () -> eventService.removeAttender(eventId, user));
+
+        assertTrue(exception.getMessage().contains("passed"));
+        verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void removeAttender_WhenNotAttender_ReturnsFalse() {
+        // Given
+        Long eventId = 1L;
+        Event event = createUpcomingEvent();
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.of(event));
+        when(eventAttenderRepo.existsByEventIdAndUserId(eventId, mockUserId)).thenReturn(false);
+
+        // When
+        boolean result = eventService.removeAttender(eventId, user);
+
+        // Then
+        assertFalse(result);
+        verify(eventAttenderRepo, never()).deleteByEventIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void removeAttender_WithNonExistentEvent_ThrowsNotFoundException() {
+        // Given
+        Long eventId = 999L;
+        UserVO user = createUserVO(mockUserId, Role.ROLE_USER);
+
+        when(eventRepository.findById(eventId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NotFoundException.class,
+                () -> eventService.removeAttender(eventId, user));
+    }
+
+    @Test
+    void getMyEvents_WithPagination_ReturnsPagedResults() {
+        // Given
+        Long userId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Event> events = List.of(createUpcomingEvent());
+
+        when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(userId), any(OffsetDateTime.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(events, pageable, 1));
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        // When
+        Page<EventPreviewDto> result = eventService.getMyEvents(userId, null, null, null, null, pageable);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals(1, result.getContent().size());
+    }
+
+    @Test
+    void getMyEvents_WithEventTypeFilter_ReturnsFilteredEvents() {
+        // Given
+        Long userId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Event> events = List.of(createUpcomingEvent());
+
+        when(eventAttenderRepo.findJoinedEventsWithSorting(
+                eq(userId), any(OffsetDateTime.class), eq(EventType.PLACE.name()), any(), any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(events, pageable, 1));
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        // When
+        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.PLACE, null, 50.0, 30.0, pageable);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+    }
+
+    @Test
+    void getMyCreatedEvents_ReturnsCreatedEventsWithCanEditTrue() {
+        // Given
+        Long userId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Event event = createUpcomingEvent();
+        event.setOrganizerId(userId);
+        Page<Event> eventPage = new PageImpl<>(Arrays.asList(event), pageable, 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), eq(pageable)))
+                .thenReturn(eventPage);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        // When
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, pageable);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        EventPreviewDto dto = result.getContent().get(0);
+        assertTrue(dto.isCanEdit());
+        assertTrue(dto.isOrganizer());
+    }
+
+    @Test
+    void getMyCreatedEvents_WithStatusFilter_ReturnsFilteredEvents() {
+        // Given
+        Long userId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Event event = createUpcomingEvent();
+        event.setOrganizerId(userId);
+        Page<Event> eventPage = new PageImpl<>(Arrays.asList(event), pageable, 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), eq(pageable)))
+                .thenReturn(eventPage);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        // When
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, EventStatus.UPCOMING, pageable);
+
+        // Then
+        assertNotNull(result);
+        result.getContent().forEach(dto ->
+                assertEquals(EventStatus.UPCOMING, dto.getStatus())
+        );
+    }
+
+    @Test
+    void getRelatedEvents_ReturnsUnionOfCreatedAndJoined() {
+        // Given
+        Long userId = 100L;
+        Pageable pageable = PageRequest.of(0, 10);
+        Event event = createUpcomingEvent();
+        event.setOrganizerId(userId);
+        Page<Event> eventPage = new PageImpl<>(Arrays.asList(event), pageable, 1);
+
+        when(eventRepository.findRelatedEventsByUserId(eq(userId), eq(pageable)))
+                .thenReturn(eventPage);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        // When
+        Page<EventPreviewDto> result = eventService.getRelatedEvents(userId, null, pageable);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(eventRepository).findRelatedEventsByUserId(eq(userId), eq(pageable));
     }
 }

--- a/service/src/test/java/greencity/service/EventStatusComputationTest.java
+++ b/service/src/test/java/greencity/service/EventStatusComputationTest.java
@@ -30,8 +30,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Unit tests for event status computation logic.
- * Tests UPCOMING, LIVE, and PASSED status determination based on event date/time occurrences.
+ * Unit tests for event status computation logic. Tests UPCOMING, LIVE, and
+ * PASSED status determination based on event date/time occurrences.
  */
 @ExtendWith(SpringExtension.class)
 class EventStatusComputationTest {
@@ -57,32 +57,32 @@ class EventStatusComputationTest {
 
     private Event buildEvent(Long id, Long organizerId, List<EventDateTimeLocation> locations) {
         Event event = Event.builder()
-                .id(id)
-                .title("Event " + id)
-                .description("Test")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Event " + id)
+            .description("Test")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
         event.setDateTimeLocations(locations);
         EventImage img = EventImage.builder()
-                .event(event)
-                .imagePath("img.jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("img.jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(List.of(img));
         return event;
     }
 
     private EventDateTimeLocation buildLocation(OffsetDateTime start, OffsetDateTime finish) {
         return EventDateTimeLocation.builder()
-                .startDate(start)
-                .finishDate(finish)
-                .latitude(50.0)
-                .longitude(30.0)
-                .build();
+            .startDate(start)
+            .finishDate(finish)
+            .latitude(50.0)
+            .longitude(30.0)
+            .build();
     }
 
     @Test
@@ -90,9 +90,8 @@ class EventStatusComputationTest {
         Long userId = 100L;
         OffsetDateTime futureStart = OffsetDateTime.now().plusDays(1);
         Event event = buildEvent(1L, userId, List.of(buildLocation(
-                futureStart,
-                futureStart.plusHours(2)
-        )));
+            futureStart,
+            futureStart.plusHours(2))));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
@@ -143,10 +142,9 @@ class EventStatusComputationTest {
         OffsetDateTime future3 = OffsetDateTime.now().plusDays(5);
 
         Event event = buildEvent(4L, userId, List.of(
-                buildLocation(future3, future3.plusHours(2)),
-                buildLocation(future1, future1.plusHours(2)),
-                buildLocation(future2, future2.plusHours(2))
-        ));
+            buildLocation(future3, future3.plusHours(2)),
+            buildLocation(future1, future1.plusHours(2)),
+            buildLocation(future2, future2.plusHours(2))));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
@@ -167,9 +165,8 @@ class EventStatusComputationTest {
         OffsetDateTime future = OffsetDateTime.now().plusDays(1);
 
         Event event = buildEvent(5L, userId, List.of(
-                buildLocation(past, past.plusHours(2)),
-                buildLocation(future, future.plusHours(2))
-        ));
+            buildLocation(past, past.plusHours(2)),
+            buildLocation(future, future.plusHours(2))));
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
 
         when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
@@ -182,4 +179,3 @@ class EventStatusComputationTest {
         assertEquals(future, dto.getNearestStart());
     }
 }
-

--- a/service/src/test/java/greencity/service/EventStatusComputationTest.java
+++ b/service/src/test/java/greencity/service/EventStatusComputationTest.java
@@ -1,0 +1,185 @@
+package greencity.service;
+
+import greencity.dto.event.EventPreviewDto;
+import greencity.entity.Event;
+import greencity.entity.EventDateTimeLocation;
+import greencity.entity.EventImage;
+import greencity.enums.EventStatus;
+import greencity.enums.Role;
+import greencity.dto.user.UserVO;
+import greencity.repository.EventAttenderRepo;
+import greencity.repository.EventDateTimeLocationRepo;
+import greencity.repository.EventImageRepo;
+import greencity.repository.EventRepo;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for event status computation logic.
+ * Tests UPCOMING, LIVE, and PASSED status determination based on event date/time occurrences.
+ */
+@ExtendWith(SpringExtension.class)
+class EventStatusComputationTest {
+    @Mock
+    private EventRepo eventRepository;
+    @Mock
+    private EventDateTimeLocationRepo dateTimeLocationRepository;
+    @Mock
+    private EventImageRepo eventImageRepository;
+    @Mock
+    private EventAttenderRepo eventAttenderRepo;
+    @Mock
+    private ImageStorageService imageStorageService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private ModelMapper mapper;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    private Event buildEvent(Long id, Long organizerId, List<EventDateTimeLocation> locations) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Event " + id)
+                .description("Test")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+        event.setDateTimeLocations(locations);
+        EventImage img = EventImage.builder()
+                .event(event)
+                .imagePath("img.jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(List.of(img));
+        return event;
+    }
+
+    private EventDateTimeLocation buildLocation(OffsetDateTime start, OffsetDateTime finish) {
+        return EventDateTimeLocation.builder()
+                .startDate(start)
+                .finishDate(finish)
+                .latitude(50.0)
+                .longitude(30.0)
+                .build();
+    }
+
+    @Test
+    void eventWithFutureStart_ReturnsUpcoming() {
+        Long userId = 100L;
+        OffsetDateTime futureStart = OffsetDateTime.now().plusDays(1);
+        Event event = buildEvent(1L, userId, List.of(buildLocation(
+                futureStart,
+                futureStart.plusHours(2)
+        )));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        assertEquals(EventStatus.UPCOMING, result.getContent().get(0).getStatus());
+    }
+
+    @Test
+    void eventWithPastStartPresentFinish_ReturnsLive() {
+        Long userId = 200L;
+        OffsetDateTime pastStart = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime futureFinish = OffsetDateTime.now().plusHours(1);
+        Event event = buildEvent(2L, userId, List.of(buildLocation(pastStart, futureFinish)));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        assertEquals(EventStatus.LIVE, result.getContent().get(0).getStatus());
+    }
+
+    @Test
+    void eventWithPastFinish_ReturnsPassed() {
+        Long userId = 300L;
+        OffsetDateTime pastStart = OffsetDateTime.now().minusDays(2);
+        OffsetDateTime pastFinish = OffsetDateTime.now().minusDays(1);
+        Event event = buildEvent(3L, userId, List.of(buildLocation(pastStart, pastFinish)));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        assertEquals(EventStatus.PASSED, result.getContent().get(0).getStatus());
+    }
+
+    @Test
+    void eventWithMultipleOccurrences_ReturnsCorrectNearestDates() {
+        Long userId = 400L;
+        OffsetDateTime future1 = OffsetDateTime.now().plusDays(1);
+        OffsetDateTime future2 = OffsetDateTime.now().plusDays(3);
+        OffsetDateTime future3 = OffsetDateTime.now().plusDays(5);
+
+        Event event = buildEvent(4L, userId, List.of(
+                buildLocation(future3, future3.plusHours(2)),
+                buildLocation(future1, future1.plusHours(2)),
+                buildLocation(future2, future2.plusHours(2))
+        ));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertEquals(future1, dto.getNearestStart());
+        assertEquals(future1.plusHours(2), dto.getNearestFinish());
+        assertEquals(EventStatus.UPCOMING, dto.getStatus());
+    }
+
+    @Test
+    void eventWithPassedAndUpcomingOccurrences_ReturnsUpcomingStatus() {
+        Long userId = 500L;
+        OffsetDateTime past = OffsetDateTime.now().minusDays(1);
+        OffsetDateTime future = OffsetDateTime.now().plusDays(1);
+
+        Event event = buildEvent(5L, userId, List.of(
+                buildLocation(past, past.plusHours(2)),
+                buildLocation(future, future.plusHours(2))
+        ));
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertEquals(EventStatus.UPCOMING, dto.getStatus());
+        assertEquals(future, dto.getNearestStart());
+    }
+}
+

--- a/service/src/test/java/greencity/service/EventTypeBucketsTest.java
+++ b/service/src/test/java/greencity/service/EventTypeBucketsTest.java
@@ -1,0 +1,223 @@
+package greencity.service;
+
+import greencity.dto.event.EventPreviewDto;
+import greencity.entity.Event;
+import greencity.entity.EventDateTimeLocation;
+import greencity.entity.EventImage;
+import greencity.enums.EventType;
+import greencity.enums.Role;
+import greencity.dto.user.UserVO;
+import greencity.repository.EventAttenderRepo;
+import greencity.repository.EventDateTimeLocationRepo;
+import greencity.repository.EventImageRepo;
+import greencity.repository.EventRepo;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for event type buckets: place, online, both.
+ * Verifies that events are correctly classified and filtered by type.
+ */
+@ExtendWith(SpringExtension.class)
+class EventTypeBucketsTest {
+    @Mock
+    private EventRepo eventRepository;
+    @Mock
+    private EventDateTimeLocationRepo dateTimeLocationRepository;
+    @Mock
+    private EventImageRepo eventImageRepository;
+    @Mock
+    private EventAttenderRepo eventAttenderRepo;
+    @Mock
+    private ImageStorageService imageStorageService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private ModelMapper mapper;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    private Event buildEvent(Long id, Long organizerId, boolean hasPlace, boolean hasOnline) {
+        Event event = Event.builder()
+                .id(id)
+                .title("Event " + id)
+                .description("Test")
+                .open(true)
+                .organizerId(organizerId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        EventDateTimeLocation loc = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .latitude(hasPlace ? 50.0 : null)
+                .longitude(hasPlace ? 30.0 : null)
+                .onlineLink(hasOnline ? "https://example.com/meeting" : null)
+                .build();
+        event.setDateTimeLocations(List.of(loc));
+
+        EventImage img = EventImage.builder()
+                .event(event)
+                .imagePath("img.jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(List.of(img));
+        return event;
+    }
+
+    @Test
+    void placeEvent_ReturnsTypesPlaceTrue() {
+        Long userId = 100L;
+        Event event = buildEvent(1L, userId, true, false);
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertTrue(dto.getTypes().isPlace());
+        assertFalse(dto.getTypes().isOnline());
+    }
+
+    @Test
+    void onlineEvent_ReturnsTypesOnlineTrue() {
+        Long userId = 200L;
+        Event event = buildEvent(2L, userId, false, true);
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertFalse(dto.getTypes().isPlace());
+        assertTrue(dto.getTypes().isOnline());
+    }
+
+    @Test
+    void hybridEvent_ReturnsBothTypesTrue() {
+        Long userId = 300L;
+        Event event = Event.builder()
+                .id(3L)
+                .title("Hybrid Event")
+                .description("Test")
+                .open(true)
+                .organizerId(userId)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        // Add both place and online locations
+        EventDateTimeLocation placeLoc = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .latitude(50.0)
+                .longitude(30.0)
+                .build();
+
+        EventDateTimeLocation onlineLoc = EventDateTimeLocation.builder()
+                .event(event)
+                .startDate(OffsetDateTime.now().plusDays(1))
+                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+                .onlineLink("https://example.com/meeting")
+                .build();
+
+        event.setDateTimeLocations(List.of(placeLoc, onlineLoc));
+
+        EventImage img = EventImage.builder()
+                .event(event)
+                .imagePath("img.jpg")
+                .main(true)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        event.setImages(List.of(img));
+
+        Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
+
+        when(eventRepository.findByOrganizerIdOrderByNearestStart(eq(userId), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyCreatedEvents(userId, null, PageRequest.of(0, 10));
+
+        EventPreviewDto dto = result.getContent().get(0);
+        assertTrue(dto.getTypes().isPlace(), "Hybrid event should have place=true");
+        assertTrue(dto.getTypes().isOnline(), "Hybrid event should have online=true");
+    }
+
+    @Test
+    void filterByPlaceType_ReturnsOnlyPlaceEvents() {
+        Long userId = 400L;
+        Event placeEvent = buildEvent(1L, userId, true, false);
+        Event onlineEvent = buildEvent(2L, userId, false, true);
+        Page<Event> page = new PageImpl<>(List.of(placeEvent, onlineEvent), PageRequest.of(0, 10), 2);
+
+        when(eventAttenderRepo.findJoinedEventsWithSorting(
+                eq(userId), any(), eq(EventType.PLACE.name()), any(), any(), any(Pageable.class)
+        )).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.PLACE, null, null, null, PageRequest.of(0, 10));
+
+        assertEquals(2, result.getTotalElements());
+        // All returned events should have place=true (based on filtering)
+    }
+
+    @Test
+    void filterByOnlineType_ReturnsOnlyOnlineEvents() {
+        Long userId = 500L;
+        Event placeEvent = buildEvent(1L, userId, true, false);
+        Event onlineEvent = buildEvent(2L, userId, false, true);
+        Page<Event> page = new PageImpl<>(List.of(placeEvent, onlineEvent), PageRequest.of(0, 10), 2);
+
+        when(eventAttenderRepo.findJoinedEventsWithSorting(
+                eq(userId), any(), eq(EventType.ONLINE.name()), any(), any(), any(Pageable.class)
+        )).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.ONLINE, null, null, null, PageRequest.of(0, 10));
+
+        assertEquals(2, result.getTotalElements());
+    }
+
+    @Test
+    void filterByBothType_ReturnsAllEvents() {
+        Long userId = 600L;
+        Event placeEvent = buildEvent(1L, userId, true, false);
+        Event onlineEvent = buildEvent(2L, userId, false, true);
+        Event hybridEvent = buildEvent(3L, userId, true, true);
+        Page<Event> page = new PageImpl<>(List.of(placeEvent, onlineEvent, hybridEvent), PageRequest.of(0, 10), 3);
+
+        when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(userId), any(), any(Pageable.class))).thenReturn(page);
+        when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
+
+        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.BOTH, null, null, null, PageRequest.of(0, 10));
+
+        assertEquals(3, result.getTotalElements());
+    }
+}
+

--- a/service/src/test/java/greencity/service/EventTypeBucketsTest.java
+++ b/service/src/test/java/greencity/service/EventTypeBucketsTest.java
@@ -30,8 +30,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for event type buckets: place, online, both.
- * Verifies that events are correctly classified and filtered by type.
+ * Tests for event type buckets: place, online, both. Verifies that events are
+ * correctly classified and filtered by type.
  */
 @ExtendWith(SpringExtension.class)
 class EventTypeBucketsTest {
@@ -57,31 +57,31 @@ class EventTypeBucketsTest {
 
     private Event buildEvent(Long id, Long organizerId, boolean hasPlace, boolean hasOnline) {
         Event event = Event.builder()
-                .id(id)
-                .title("Event " + id)
-                .description("Test")
-                .open(true)
-                .organizerId(organizerId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(id)
+            .title("Event " + id)
+            .description("Test")
+            .open(true)
+            .organizerId(organizerId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         EventDateTimeLocation loc = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .latitude(hasPlace ? 50.0 : null)
-                .longitude(hasPlace ? 30.0 : null)
-                .onlineLink(hasOnline ? "https://example.com/meeting" : null)
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .latitude(hasPlace ? 50.0 : null)
+            .longitude(hasPlace ? 30.0 : null)
+            .onlineLink(hasOnline ? "https://example.com/meeting" : null)
+            .build();
         event.setDateTimeLocations(List.of(loc));
 
         EventImage img = EventImage.builder()
-                .event(event)
-                .imagePath("img.jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("img.jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(List.of(img));
         return event;
     }
@@ -122,39 +122,39 @@ class EventTypeBucketsTest {
     void hybridEvent_ReturnsBothTypesTrue() {
         Long userId = 300L;
         Event event = Event.builder()
-                .id(3L)
-                .title("Hybrid Event")
-                .description("Test")
-                .open(true)
-                .organizerId(userId)
-                .createdAt(OffsetDateTime.now())
-                .updatedAt(OffsetDateTime.now())
-                .build();
+            .id(3L)
+            .title("Hybrid Event")
+            .description("Test")
+            .open(true)
+            .organizerId(userId)
+            .createdAt(OffsetDateTime.now())
+            .updatedAt(OffsetDateTime.now())
+            .build();
 
         // Add both place and online locations
         EventDateTimeLocation placeLoc = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .latitude(50.0)
-                .longitude(30.0)
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .latitude(50.0)
+            .longitude(30.0)
+            .build();
 
         EventDateTimeLocation onlineLoc = EventDateTimeLocation.builder()
-                .event(event)
-                .startDate(OffsetDateTime.now().plusDays(1))
-                .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
-                .onlineLink("https://example.com/meeting")
-                .build();
+            .event(event)
+            .startDate(OffsetDateTime.now().plusDays(1))
+            .finishDate(OffsetDateTime.now().plusDays(1).plusHours(2))
+            .onlineLink("https://example.com/meeting")
+            .build();
 
         event.setDateTimeLocations(List.of(placeLoc, onlineLoc));
 
         EventImage img = EventImage.builder()
-                .event(event)
-                .imagePath("img.jpg")
-                .main(true)
-                .createdAt(OffsetDateTime.now())
-                .build();
+            .event(event)
+            .imagePath("img.jpg")
+            .main(true)
+            .createdAt(OffsetDateTime.now())
+            .build();
         event.setImages(List.of(img));
 
         Page<Event> page = new PageImpl<>(List.of(event), PageRequest.of(0, 10), 1);
@@ -177,11 +177,11 @@ class EventTypeBucketsTest {
         Page<Event> page = new PageImpl<>(List.of(placeEvent, onlineEvent), PageRequest.of(0, 10), 2);
 
         when(eventAttenderRepo.findJoinedEventsWithSorting(
-                eq(userId), any(), eq(EventType.PLACE.name()), any(), any(), any(Pageable.class)
-        )).thenReturn(page);
+            eq(userId), any(), eq(EventType.PLACE.name()), any(), any(), any(Pageable.class))).thenReturn(page);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
-        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.PLACE, null, null, null, PageRequest.of(0, 10));
+        Page<EventPreviewDto> result =
+            eventService.getMyEvents(userId, EventType.PLACE, null, null, null, PageRequest.of(0, 10));
 
         assertEquals(2, result.getTotalElements());
         // All returned events should have place=true (based on filtering)
@@ -195,11 +195,11 @@ class EventTypeBucketsTest {
         Page<Event> page = new PageImpl<>(List.of(placeEvent, onlineEvent), PageRequest.of(0, 10), 2);
 
         when(eventAttenderRepo.findJoinedEventsWithSorting(
-                eq(userId), any(), eq(EventType.ONLINE.name()), any(), any(), any(Pageable.class)
-        )).thenReturn(page);
+            eq(userId), any(), eq(EventType.ONLINE.name()), any(), any(), any(Pageable.class))).thenReturn(page);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
-        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.ONLINE, null, null, null, PageRequest.of(0, 10));
+        Page<EventPreviewDto> result =
+            eventService.getMyEvents(userId, EventType.ONLINE, null, null, null, PageRequest.of(0, 10));
 
         assertEquals(2, result.getTotalElements());
     }
@@ -215,9 +215,9 @@ class EventTypeBucketsTest {
         when(eventAttenderRepo.findJoinedEventsDefaultSorting(eq(userId), any(), any(Pageable.class))).thenReturn(page);
         when(userService.findById(userId)).thenReturn(UserVO.builder().id(userId).role(Role.ROLE_USER).build());
 
-        Page<EventPreviewDto> result = eventService.getMyEvents(userId, EventType.BOTH, null, null, null, PageRequest.of(0, 10));
+        Page<EventPreviewDto> result =
+            eventService.getMyEvents(userId, EventType.BOTH, null, null, null, PageRequest.of(0, 10));
 
         assertEquals(3, result.getTotalElements());
     }
 }
-


### PR DESCRIPTION
Implement the EventPreviewDto contract, and add Swagger documentation, and integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event previews include ownership/permission flags (isOrganizer, canEdit, canCancelJoin), event types (place/online), distance, nearest dates and visibility ("open"/"closed").

* **API Changes**
  * Preview payload restructured: organizerId removed; new contextual fields added (types, distance, visibility, flags).
  * Event creation now documented to return 201 (Created).
  * Attendee removal operation clarified with explicit cancellation semantics for upcoming/live vs past events.

* **Documentation**
  * OpenAPI docs improved with clearer operation summaries, parameter descriptions, and explicit response messages.

* **Tests**
  * Extensive new/updated unit and integration tests for mapping, status computation, permissions, types, distance, repos, and cancellation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->