### PR TITLE
Fix JaCoCo report transmission to SonarCloud

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-    # Checks-out your greencity.repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your greencity.repository under $GITHUB_WORKSPACE, so your job can access it
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -49,10 +49,10 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-#       - name: Set up Go
-#         uses: actions/setup-go@v3
-#         with:
-#           go-version: 1.18
+      #       - name: Set up Go
+      #         uses: actions/setup-go@v3
+      #         with:
+      #           go-version: 1.18
 
       - name: Maven Build and Sonar Analysis
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
@@ -74,6 +74,7 @@ jobs:
           mvn clean install verify
           echo "Forcing generation of jacoco-aggregate report..."
           mvn jacoco:report-aggregate
+          
           REPORT_PATH="target/site/jacoco-aggregate/jacoco.xml"
           if [ -f "$REPORT_PATH" ]; then
             echo "SUCCESS: JaCoCo report found at $REPORT_PATH. Continuing to Sonar analysis."
@@ -81,8 +82,10 @@ jobs:
             echo "ERROR: JaCoCo report NOT found at $REPORT_PATH. The report generation step failed."
             exit 1 # Fail the job if the report is missing
           fi
+          
           echo "--- Starting Sonar Analysis ---"
-          SONAR_CMD="mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+          
+          SONAR_CMD="mvn sonar:sonar \
             -Dsonar.projectKey=GreenCity-UA-4415-01_GreenCityMVP \
             -Dsonar.organization=greencity-ua-4415-01 \
             -Dsonar.token=${SONAR_TOKEN} \
@@ -131,22 +134,22 @@ jobs:
           push: true
           tags: ${{ env.dockerRepoName }}:test-${{ env.GITHUB_SHA_SHORT }}
 
-#       - name: Kubernetes Set Context
-#         uses: Azure/k8s-set-context@v3.0
-#         with:
-#           kubeconfig: ${{ secrets.KUBE_CONFIG }}
+      #       - name: Kubernetes Set Context
+      #         uses: Azure/k8s-set-context@v3.0
+      #         with:
+      #           kubeconfig: ${{ secrets.KUBE_CONFIG }}
       
-#       - name: Set up Postgres
-#         run: kubectl scale deploy postgres --replicas=1 -n test
+      #       - name: Set up Postgres
+      #         run: kubectl scale deploy postgres --replicas=1 -n test
       
-#       - name: Kubernetes tests
-#         run: |
-#           cd chart-test
-#           go test -v ./...
+      #       - name: Kubernetes tests
+      #         run: |
+      #           cd chart-test
+      #           go test -v ./...
       
-#       - name: Post Set up Postgres
-#         if: success() || failure()
-#         run: kubectl scale deploy postgres --replicas=0 -n test
+      #       - name: Post Set up Postgres
+      #         if: success() || failure()
+      #         run: kubectl scale deploy postgres --replicas=0 -n test
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Deploy 🚀

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,16 +72,6 @@ jobs:
         # 8. Execute the final command - run the Sonar scanner conditionally (PR vs. Push).
         run: |
           mvn clean install verify
-          echo "Forcing generation of jacoco-aggregate report..."
-          mvn jacoco:report-aggregate
-          
-          REPORT_PATH="target/site/jacoco-aggregate/jacoco.xml"
-          if [ -f "$REPORT_PATH" ]; then
-            echo "SUCCESS: JaCoCo report found at $REPORT_PATH. Continuing to Sonar analysis."
-          else
-            echo "ERROR: JaCoCo report NOT found at $REPORT_PATH. The report generation step failed."
-            exit 1 # Fail the job if the report is missing
-          fi
           
           echo "--- Starting Sonar Analysis ---"
           
@@ -89,7 +79,6 @@ jobs:
             -Dsonar.projectKey=GreenCity-UA-4415-01_GreenCityMVP \
             -Dsonar.organization=greencity-ua-4415-01 \
             -Dsonar.token=${SONAR_TOKEN} \
-            -Dsonar.coverage.jacoco.xmlReportPaths=${REPORT_PATH} \
             -Dsonar.qualitygate.wait=false \
             -Dsonar.ws.timeout=120"
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,9 @@ jobs:
             -Dsonar.token=${SONAR_TOKEN} \
             -Dsonar.coverage.jacoco.xmlReportPaths=${REPORT_PATH} \
             -Dsonar.qualitygate.wait=false \
-            -Dsonar.ws.timeout=120"
+            -Dsonar.ws.timeout=120" \
+            -Dsonar.sources=service-api/src/main/java,dao/src/main/java,core/src/main/java,service/src/main/java \
+            -Dsonar.java.binaries=service-api/target/classes,dao/target/classes,core/target/classes,service/target/classes"
           
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "--- Adding Pull Request parameters for Sonar Analysis ---"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,11 +64,12 @@ jobs:
           PR_BASE: ${{ github.base_ref }}
         # 1. Build and run tests, which generates the merged jacoco.exec data.
         # 2. Generate the jacoco-aggregate XML report file explicitly.
-        # 3. Define the base Sonar command (always required parameters).
-        # 4. Conditionally add Pull Request parameters only on pull_request events.
-        # 5. Execute the final command - run the Sonar scanner conditionally (PR vs. Push).
-        # 6. For push analysis, we explicitly set the branch name to ensure consistency.
-        # 7. Change qualitygate.wait to TRUE once we figure out how to properly incorporate incremental test reports.
+        # 3. Explicitly run the report-aggregate goal to ensure the XML report is created right before Sonar runs.
+        # 4. Verify the report exists before starting Sonar and fail the job if the report is missing.
+        # 5. Define the base Sonar command (always required parameters).
+        # 6. Change qualitygate.wait to TRUE once we figure out how to properly incorporate incremental test reports.
+        # 7. For push analysis, we explicitly set the branch name to ensure consistency.
+        # 8. Execute the final command - run the Sonar scanner conditionally (PR vs. Push).
         run: |
           mvn clean install verify
           echo "Forcing generation of jacoco-aggregate report..."
@@ -85,7 +86,7 @@ jobs:
             -Dsonar.projectKey=GreenCity-UA-4415-01_GreenCityMVP \
             -Dsonar.organization=greencity-ua-4415-01 \
             -Dsonar.token=${SONAR_TOKEN} \
-            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco-aggregate/jacoco.xml \
+            -Dsonar.coverage.jacoco.xmlReportPaths=${REPORT_PATH} \
             -Dsonar.qualitygate.wait=false \
             -Dsonar.ws.timeout=120"
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,9 +91,7 @@ jobs:
             -Dsonar.token=${SONAR_TOKEN} \
             -Dsonar.coverage.jacoco.xmlReportPaths=${REPORT_PATH} \
             -Dsonar.qualitygate.wait=false \
-            -Dsonar.ws.timeout=120 \
-            -Dsonar.sources=service-api/src/main/java,dao/src/main/java,core/src/main/java,service/src/main/java \
-            -Dsonar.java.binaries=service-api/target/classes,dao/target/classes,core/target/classes,service/target/classes"
+            -Dsonar.ws.timeout=120"
           
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "--- Adding Pull Request parameters for Sonar Analysis ---"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,15 @@ jobs:
         # 7. Change qualitygate.wait to TRUE once we figure out how to properly incorporate incremental test reports.
         run: |
           mvn clean install verify
+          echo "Forcing generation of jacoco-aggregate report..."
+          mvn jacoco:report-aggregate
+          REPORT_PATH="target/site/jacoco-aggregate/jacoco.xml"
+          if [ -f "$REPORT_PATH" ]; then
+            echo "SUCCESS: JaCoCo report found at $REPORT_PATH. Continuing to Sonar analysis."
+          else
+            echo "ERROR: JaCoCo report NOT found at $REPORT_PATH. The report generation step failed."
+            exit 1 # Fail the job if the report is missing
+          fi
           echo "--- Starting Sonar Analysis ---"
           SONAR_CMD="mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
             -Dsonar.projectKey=GreenCity-UA-4415-01_GreenCityMVP \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
             -Dsonar.token=${SONAR_TOKEN} \
             -Dsonar.coverage.jacoco.xmlReportPaths=${REPORT_PATH} \
             -Dsonar.qualitygate.wait=false \
-            -Dsonar.ws.timeout=120" \
+            -Dsonar.ws.timeout=120 \
             -Dsonar.sources=service-api/src/main/java,dao/src/main/java,core/src/main/java,service/src/main/java \
             -Dsonar.java.binaries=service-api/target/classes,dao/target/classes,core/target/classes,service/target/classes"
           

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
         <sonar.java.binaries>
             target/classes
         </sonar.java.binaries>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,10 @@
         <jjwt.version>0.12.5</jjwt.version>
         <sonar.maven.plugin.version>3.11.0.3922</sonar.maven.plugin.version>
         <sonar.sources>
-            service-api/src/main/java,
-            dao/src/main/java,
-            core/src/main/java,
-            service/src/main/java
+            src/main/java
         </sonar.sources>
         <sonar.java.binaries>
-            service-api/target/classes,
-            dao/target/classes,
-            core/target/classes,
-            service/target/classes
+            target/classes
         </sonar.java.binaries>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,18 @@
         <net.java.dev.jna.version>5.14.0</net.java.dev.jna.version>
         <jjwt.version>0.12.5</jjwt.version>
         <sonar.maven.plugin.version>3.11.0.3922</sonar.maven.plugin.version>
+        <sonar.sources>
+            service-api/src/main/java,
+            dao/src/main/java,
+            core/src/main/java,
+            service/src/main/java
+        </sonar.sources>
+        <sonar.java.binaries>
+            service-api/target/classes,
+            dao/target/classes,
+            core/target/classes,
+            service/target/classes
+        </sonar.java.binaries>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,17 @@
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
         <net.java.dev.jna.version>5.14.0</net.java.dev.jna.version>
         <jjwt.version>0.12.5</jjwt.version>
+        <sonar.maven.plugin.version>3.11.0.3922</sonar.maven.plugin.version>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar.maven.plugin.version}</version>
+            </plugin>
+
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs an aggregated coverage report, verifies it exists, and fails the pipeline if missing.
  * Code-quality scanner invocation streamlined and unified for PR vs push events while appending event-specific parameters.
  * Added Maven-based SonarQube scanner support and properties to enable in-build quality scanning; pipeline comments and formatting clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->